### PR TITLE
Feature/DEV-402 NFT ID Fixes

### DIFF
--- a/.env.mainnet.local
+++ b/.env.mainnet.local
@@ -1,0 +1,6 @@
+REACT_APP_CHAIN_ID=reb_1111-1
+REACT_APP_REST_URL=https://api.rebuschain.com:1317
+REACT_APP_RPC_URL=https://api.rebuschain.com:26657
+REACT_APP_METAMASK_URL=https://api.rebuschain.com:8545
+REACT_APP_NETWORK_TYPE=mainnet
+REACT_APP_CHAIN_NAME=Rebus

--- a/.env.testnet.local
+++ b/.env.testnet.local
@@ -1,0 +1,5 @@
+REACT_APP_CHAIN_ID=reb_3333-1
+REACT_APP_REST_URL=https://api.rebustestnet.com:1317
+REACT_APP_RPC_URL=https://api.rebustestnet.com:26657
+REACT_APP_METAMASK_URL=https://api.rebustestnet.com:8545
+REACT_APP_CHAIN_NAME="Rebus Testnet"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 		"dev": "cross-env NODE_ENV=development react-env && yarn build:css && webpack-dev-server",
 		"dev:alphanet": "yarn react-env:alphanet && cross-env NODE_ENV=development webpack-dev-server",
 		"dev:testnet": "yarn react-env:testnet && cross-env NODE_ENV=development webpack-dev-server",
+		"dev:testnet:local": "yarn react-env:testnet:local && cross-env NODE_ENV=development webpack-dev-server",
 		"dev:mainnet": "yarn react-env:mainnet && cross-env NODE_ENV=development webpack-dev-server",
+		"dev:mainnet:local": "yarn react-env:mainnet:local && cross-env NODE_ENV=development webpack-dev-server",
 		"dev:analyzer": "cross-env NODE_ENV=development ANALYZER=true webpack",
 		"test": "jest --passWithNoTests --runInBand",
 		"lint-test": "eslint \"src/**/*\" webpack.config.js && prettier --check \"src/**/*\" webpack.config.js",
@@ -18,7 +20,9 @@
 		"react-env": "react-env --env APP_ENV",
 		"react-env:alphanet": "cross-env APP_ENV=alphanet react-env --env APP_ENV",
 		"react-env:testnet": "cross-env APP_ENV=testnet react-env --env APP_ENV",
+		"react-env:testnet:local": "cross-env APP_ENV=testnet.local react-env --env APP_ENV",
 		"react-env:mainnet": "cross-env APP_ENV=mainnet react-env --env APP_ENV",
+		"react-env:mainnet:local": "cross-env APP_ENV=mainnet.local react-env --env APP_ENV",
 		"postinstall": "patch-package"
 	},
 	"pre-commit": [

--- a/public/assets/backgrounds/no-flag.svg
+++ b/public/assets/backgrounds/no-flag.svg
@@ -1,3 +1,0 @@
-<svg width="56" height="36" viewBox="0 0 56 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0.5 0.5H54.2976L0.5 35.0842V0.5ZM55.5 35.5H1.70241L55.5 0.915832V35.5Z" fill="#4F4F4F" stroke="#828282"/>
-</svg>

--- a/src/components/common/input/file-input.tsx
+++ b/src/components/common/input/file-input.tsx
@@ -12,6 +12,7 @@ export type FileInputProps = {
 	onChange: (name: string, value: Media | undefined) => void;
 	name?: string;
 	placeholder?: string;
+	useGrayscale?: boolean;
 	value?: Media;
 };
 
@@ -21,6 +22,7 @@ export const FileInput: React.FC<FileInputProps> = ({
 	onChange,
 	name = '',
 	placeholder,
+	useGrayscale,
 	value,
 }) => {
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -59,6 +61,7 @@ export const FileInput: React.FC<FileInputProps> = ({
 					backgroundPosition: 'center',
 					backgroundRepeat: 'no-repeat',
 					backgroundSize,
+					filter: useGrayscale ? 'grayscale(100%)' : undefined,
 					height: '115px',
 					width: '100px',
 				}}

--- a/src/components/common/input/file-input.tsx
+++ b/src/components/common/input/file-input.tsx
@@ -12,7 +12,7 @@ export type FileInputProps = {
 	onChange: (name: string, value: Media | undefined) => void;
 	name?: string;
 	placeholder?: string;
-	useGrayscale?: boolean;
+	useWhitescale?: boolean;
 	value?: Media;
 };
 
@@ -22,7 +22,7 @@ export const FileInput: React.FC<FileInputProps> = ({
 	onChange,
 	name = '',
 	placeholder,
-	useGrayscale,
+	useWhitescale,
 	value,
 }) => {
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -57,15 +57,21 @@ export const FileInput: React.FC<FileInputProps> = ({
 			<div
 				className="bg-gray-1 rounded-2lg flex-shrink-0"
 				style={{
-					backgroundImage: value ? `url(${value.source})` : undefined,
-					backgroundPosition: 'center',
-					backgroundRepeat: 'no-repeat',
-					backgroundSize,
-					filter: useGrayscale ? 'grayscale(100%)' : undefined,
 					height: '115px',
 					width: '100px',
-				}}
-			/>
+				}}>
+				<div
+					style={{
+						backgroundImage: value ? `url(${value.source})` : undefined,
+						backgroundPosition: 'center',
+						backgroundRepeat: 'no-repeat',
+						backgroundSize,
+						filter: useWhitescale ? 'brightness(0) invert(1)' : undefined,
+						height: '100%',
+						width: '100%',
+					}}
+				/>
+			</div>
 
 			<div className="ml-2.5">
 				<label className="block text-white text-base mb-2.5">File Upload</label>

--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -3,22 +3,25 @@ import classNames from 'classnames';
 import { ReactSVG } from 'react-svg';
 import { DateInput, DateInputProps } from './date-input';
 import { FileInput, FileInputProps } from './file-input';
-import { SelectInput, SelectInputProps, Option } from './select-input';
+import { SelectInput, SelectInputProps } from './select-input';
 import { TextInput, TextInputProps } from './text-input';
 import { Media } from 'src/types/nft-id';
+import { TextareaInput, TextareaInputProps } from './textarea-input';
 
 export enum InputTypes {
 	Date = 'date',
 	File = 'file',
 	Select = 'select',
 	Text = 'text',
+	Textarea = 'textarea',
 }
 
 export interface InputProps
-	extends Omit<TextInputProps, 'onChange' | 'value'>,
+	extends Omit<TextInputProps, 'onChange' | 'onRawChange' | 'onClick' | 'value'>,
 		Omit<DateInputProps, 'onChange' | 'value'>,
 		Omit<FileInputProps, 'onChange' | 'value'>,
-		Omit<SelectInputProps, 'onChange' | 'value'> {
+		Omit<SelectInputProps, 'onChange' | 'value'>,
+		Omit<TextareaInputProps, 'onChange' | 'onRawChange' | 'onClick' | 'value'> {
 	className?: string;
 	hide?: boolean;
 	label?: string;
@@ -26,7 +29,10 @@ export interface InputProps
 		| TextInputProps['onChange']
 		| DateInputProps['onChange']
 		| FileInputProps['onChange']
-		| SelectInputProps['onChange'];
+		| SelectInputProps['onChange']
+		| TextareaInputProps['onChange'];
+	onClick?: TextInputProps['onClick'] | TextareaInputProps['onClick'];
+	onRawChange?: TextInputProps['onRawChange'] | TextareaInputProps['onRawChange'];
 	onVisibilityChange: (name: string, value: boolean) => void;
 	style?: React.CSSProperties;
 	type?: InputTypes;
@@ -39,11 +45,14 @@ export const Input: React.FC<InputProps> = ({
 	className,
 	hide,
 	label,
+	maxLength,
 	name = '',
 	onChange,
 	onVisibilityChange,
 	options,
 	placeholder,
+	useGrayscale,
+	rows,
 	style,
 	type,
 	value,
@@ -64,6 +73,7 @@ export const Input: React.FC<InputProps> = ({
 					onChange={onChange as FileInputProps['onChange']}
 					name={name}
 					placeholder={placeholder}
+					useGrayscale={useGrayscale}
 					value={value as Media | undefined}
 				/>
 			);
@@ -78,10 +88,22 @@ export const Input: React.FC<InputProps> = ({
 				/>
 			);
 			break;
+		case InputTypes.Textarea:
+			content = (
+				<TextareaInput
+					onChange={onChange as TextareaInputProps['onChange']}
+					maxLength={maxLength}
+					name={name}
+					placeholder={placeholder}
+					rows={rows}
+					value={value as string | undefined}
+				/>
+			);
+			break;
 		default:
 			content = (
 				<TextInput
-					onChange={onChange as DateInputProps['onChange']}
+					onChange={onChange as TextInputProps['onChange']}
 					name={name}
 					placeholder={placeholder}
 					value={value as string | undefined}

--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -51,7 +51,7 @@ export const Input: React.FC<InputProps> = ({
 	onVisibilityChange,
 	options,
 	placeholder,
-	useGrayscale,
+	useWhitescale,
 	rows,
 	style,
 	type,
@@ -73,7 +73,7 @@ export const Input: React.FC<InputProps> = ({
 					onChange={onChange as FileInputProps['onChange']}
 					name={name}
 					placeholder={placeholder}
-					useGrayscale={useGrayscale}
+					useWhitescale={useWhitescale}
 					value={value as Media | undefined}
 				/>
 			);

--- a/src/components/common/input/select-input.tsx
+++ b/src/components/common/input/select-input.tsx
@@ -38,7 +38,7 @@ const styles: StylesConfig<Option> = {
 	menu: styles => ({ ...styles, backgroundColor: '#2D3D77' }),
 	placeholder: styles => ({ ...styles, color: 'rgba(255, 255, 255, 0.5)' }),
 	singleValue: (styles, { data }) => ({ ...styles, color: 'white !important' }),
-	valueContainer: styles => ({ ...styles, paddingBottom: '4px', paddingTop: '4px' }),
+	valueContainer: styles => ({ ...styles, padding: '4px 12px' }),
 };
 
 export const SelectInput: React.FC<SelectInputProps> = ({

--- a/src/components/common/input/textarea-input.tsx
+++ b/src/components/common/input/textarea-input.tsx
@@ -1,0 +1,57 @@
+import classNames from 'classnames';
+import React, { ChangeEventHandler, KeyboardEventHandler, MouseEventHandler } from 'react';
+
+export type TextareaInputProps = {
+	className?: string;
+	onClick?: MouseEventHandler<HTMLTextAreaElement>;
+	onChange?: (name: string, value: string) => void;
+	onRawChange?: ChangeEventHandler<HTMLTextAreaElement>;
+	maxLength?: number;
+	name?: string;
+	placeholder?: string;
+	readonly?: boolean;
+	resize?: 'none' | 'both' | 'horizontal' | 'vertical';
+	rows?: number;
+	style?: React.CSSProperties;
+	value?: string;
+};
+
+export const TextareaInput: React.FC<TextareaInputProps> = ({
+	className,
+	onClick,
+	onChange,
+	onRawChange,
+	maxLength,
+	name = '',
+	placeholder,
+	readonly,
+	rows,
+	style,
+	value,
+}) => {
+	return (
+		<textarea
+			className={classNames(className, 'bg-white bg-opacity-10 rounded-2lg text-white text-base py-2 px-3.5 w-full')}
+			disabled={readonly}
+			onClick={onClick}
+			onChange={e => {
+				if (onRawChange) {
+					onRawChange(e);
+				}
+
+				if (onChange) {
+					onChange(name, maxLength ? e.target.value.slice(0, maxLength) : e.target.value);
+				}
+			}}
+			maxLength={maxLength}
+			name={name}
+			placeholder={placeholder}
+			rows={rows}
+			style={{
+				...(style || {}),
+				resize: 'none',
+			}}
+			value={value || ''}
+		/>
+	);
+};

--- a/src/components/nft-id/color-picker.tsx
+++ b/src/components/nft-id/color-picker.tsx
@@ -29,9 +29,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ className, onChange, o
 					!isOpen && 'rounded-bl-2lg rounded-br-2lg'
 				)}
 				onClick={() => setIsOpen(!isOpen)}>
-				<div className="text-left black mr-2" style={{ width: '44px' }}>
-					{value.name}
-				</div>
+				<div className="text-left black mr-2">{value.name}</div>
 
 				<div className="flex">
 					{value.colors.map((color, index) => (

--- a/src/components/nft-id/data-item.tsx
+++ b/src/components/nft-id/data-item.tsx
@@ -12,13 +12,19 @@ export const DataItem: React.FC<DataItemProps> = ({ children, className, isBlurr
 	return (
 		<div className={classNames(className, 'flex flex-col')}>
 			{label && (
-				<div className="text-xs font-bold uppercase opacity-60" style={{ lineHeight: '14px' }}>
+				<div
+					className="text-xs font-bold uppercase opacity-60"
+					style={{ lineHeight: '14px', textShadow: '0px 1px rgba(0, 0, 0, 0.6)' }}>
 					{label}
 				</div>
 			)}
 			<div
 				className="text-xl gray-6 font-bold"
-				style={{ filter: isBlurred ? 'blur(7.5px)' : undefined, lineHeight: '28px' }}>
+				style={{
+					filter: isBlurred ? 'blur(7.5px)' : undefined,
+					lineHeight: '28px',
+					textShadow: '0px 1px rgba(0, 0, 0, 0.6)',
+				}}>
 				{value || children}
 			</div>
 		</div>

--- a/src/components/nft-id/id-form.tsx
+++ b/src/components/nft-id/id-form.tsx
@@ -145,7 +145,7 @@ export const IdForm: React.FC<IdFormProps> = ({ className, data, onChange, onVis
 				backgroundSize: 'contain',
 				hide: data.signatureFileHidden,
 				value: data.signatureFile,
-				useGrayscale: true,
+				useWhitescale: true,
 			},
 		],
 	];

--- a/src/components/nft-id/id-form.tsx
+++ b/src/components/nft-id/id-form.tsx
@@ -13,6 +13,7 @@ type IdFormProps = {
 };
 
 const dateOfBirthStyle = { minWidth: '180px' };
+const textareaStyle = { resize: 'none' };
 
 const COUNTRY_OPTIONS = Object.values(countries)
 	.sort((a, b) => a.localeCompare(b))
@@ -100,38 +101,12 @@ export const IdForm: React.FC<IdFormProps> = ({ className, data, onChange, onVis
 				className: 'mb-1',
 				onChange,
 				onVisibilityChange,
-				placeholder: 'Street Address',
+				placeholder: 'Permanent Address',
 				hide: data.addressHidden,
 				value: data.address,
-			},
-		],
-		[
-			{
-				name: 'city',
-				className: 'mb-1 mr-1',
-				onChange,
-				onVisibilityChange,
-				placeholder: 'City',
-				width: 'w-7/12',
-				value: data.city,
-			},
-			{
-				name: 'state',
-				className: 'mb-1 mr-1',
-				onChange,
-				onVisibilityChange,
-				placeholder: 'State',
-				width: 'w-2/12',
-				value: data.state,
-			},
-			{
-				name: 'zipCode',
-				className: 'mb-1',
-				onChange,
-				onVisibilityChange,
-				placeholder: 'Zip Code',
-				width: 'w-3/12',
-				value: data.zipCode,
+				type: InputTypes.Textarea,
+				maxLength: 150,
+				rows: 2,
 			},
 		],
 		[
@@ -170,6 +145,7 @@ export const IdForm: React.FC<IdFormProps> = ({ className, data, onChange, onVis
 				backgroundSize: 'contain',
 				hide: data.signatureFileHidden,
 				value: data.signatureFile,
+				useGrayscale: true,
 			},
 		],
 	];

--- a/src/components/nft-id/public-preview.tsx
+++ b/src/components/nft-id/public-preview.tsx
@@ -190,11 +190,10 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 
 							{data.nationality && (
 								<div className="flex items-center mt-6">
-									<img
-										className="flex-shrink-0 rounded-md opacity-90"
-										src={data.nationalityHidden ? '/public/assets/backgrounds/no-flag.svg' : nationalityFlagSvg}
-										style={{ height: '36px' }}
-									/>
+									<div className="relative flex-shrink-0">
+										<img className="rounded-md opacity-90" src={nationalityFlagSvg} style={{ height: '36px' }} />
+										{data.nationalityHidden && <NoFlag className="rounded-md" />}
+									</div>
 									<DataItem
 										className="ml-3"
 										isBlurred={data.nationalityHidden}
@@ -235,7 +234,7 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 										className="mt-1"
 										src={data.signatureFile.source}
 										style={{
-											filter: 'grayscale(100%)',
+											filter: 'brightness(0) invert(1)',
 											height: '38px',
 											maxWidth: '193px',
 											objectFit: 'contain',
@@ -297,5 +296,30 @@ const ReactSVGStyled = styled(ReactSVG as any)`
 	svg {
 		height: 24px;
 		width: 24px;
+	}
+`;
+
+const NoFlag = styled.div`
+	background-color: #4f4f4f;
+	height: 100%;
+	left: 0;
+	overflow: hidden;
+	position: absolute;
+	top: 0;
+	width: 100%;
+
+	&:after {
+		background: linear-gradient(
+			to top left,
+			rgba(0, 0, 0, 0) 0%,
+			rgba(0, 0, 0, 0) calc(50% - 0.8px),
+			#828282 50%,
+			rgba(0, 0, 0, 0) calc(50% + 0.8px),
+			rgba(0, 0, 0, 0) 100%
+		);
+		content: '';
+		height: 100%;
+		position: absolute;
+		width: 100%;
 	}
 `;

--- a/src/components/nft-id/public-preview.tsx
+++ b/src/components/nft-id/public-preview.tsx
@@ -191,8 +191,12 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 							{data.nationality && (
 								<div className="flex items-center mt-6">
 									<div className="relative flex-shrink-0">
-										<img className="rounded-md opacity-90" src={nationalityFlagSvg} style={{ height: '36px' }} />
-										{data.nationalityHidden && <NoFlag className="rounded-md" />}
+										<img
+											className="rounded opacity-90"
+											src={nationalityFlagSvg}
+											style={{ objectFit: 'contain', objectPosition: 'center', width: '56px' }}
+										/>
+										{data.nationalityHidden && <NoFlag className="rounded" />}
 									</div>
 									<DataItem
 										className="ml-3"

--- a/src/components/nft-id/public-preview.tsx
+++ b/src/components/nft-id/public-preview.tsx
@@ -19,28 +19,6 @@ const countriesToAbbvMap = Object.entries(countries).reduce((map, [abbv, country
 	return map;
 }, {} as Record<string, string>);
 
-const getMiddleAddressLine = (data: NftIdData) => {
-	let middleAddressLine = data.city;
-
-	if (middleAddressLine && (data.state || data.zipCode)) {
-		middleAddressLine += ', ';
-	}
-
-	if (data.state) {
-		middleAddressLine += data.state;
-	}
-
-	if (data.zipCode) {
-		if (data.state) {
-			middleAddressLine += ' ';
-		}
-
-		middleAddressLine += data.zipCode;
-	}
-
-	return middleAddressLine;
-};
-
 const getBackgroundLevel = (data: NftIdData) => {
 	let level = 8;
 
@@ -60,7 +38,7 @@ const getBackgroundLevel = (data: NftIdData) => {
 		level--;
 	}
 
-	if (data.address && data.city && data.state && data.zipCode) {
+	if (data.address && data.country) {
 		level--;
 	}
 
@@ -82,16 +60,24 @@ const ID_WIDTH = 712;
 
 const COLOR_OPTIONS = [
 	{
-		name: 'Red',
-		colors: ['#ff5454', '#F8A8A8', '#FC4343', '#860020', '#860020'],
-	},
-	{
 		name: 'Blue',
 		colors: ['#A8E0FF', '#7BC8FF', '#0295FF', '#0B0084', '#0B0084'],
 	},
 	{
+		name: 'Red',
+		colors: ['#ff5454', '#F8A8A8', '#FC4343', '#860020', '#860020'],
+	},
+	{
 		name: 'Pink',
 		colors: ['#EE8BF0', '#F24BF5', '#B34BF5', '#96005C', '#411000'],
+	},
+	{
+		name: 'Blue and Pink',
+		colors: ['#a7cfba', '#9fe0e0', '#2083DF', '#8A008A', '#33001E'],
+	},
+	{
+		name: 'Green',
+		colors: ['#baafa8', '#D4D2AA', '#209159', '#00555A', '#002434'],
 	},
 	{
 		name: 'Black',
@@ -100,8 +86,6 @@ const COLOR_OPTIONS = [
 ];
 
 export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, onChangeColor }) => {
-	const hasAddress = data.address || data.city || data.country || data.zipCode || data.state;
-	const middleAddressLine = getMiddleAddressLine(data);
 	const level = getBackgroundLevel(data);
 
 	const [backgroundImage, setBackgroundImage] = useState('');
@@ -170,7 +154,9 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 						<div>
 							<div className="flex items-center">
 								<ReactSVGStyled src="/public/assets/main/rebus-logo-single.svg" />
-								<div className="ml-2">REBUS CHAIN NFT IDENTITY CARD</div>
+								<div className="ml-2" style={{ textShadow: '0px 1px rgba(0, 0, 0, 0.6)' }}>
+									REBUS CHAIN NFT IDENTITY CARD
+								</div>
 							</div>
 
 							{data.name && (
@@ -205,7 +191,7 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 							{data.nationality && (
 								<div className="flex items-center mt-6">
 									<img
-										className="flex-shrink-0"
+										className="flex-shrink-0 rounded-md opacity-90"
 										src={data.nationalityHidden ? '/public/assets/backgrounds/no-flag.svg' : nationalityFlagSvg}
 										style={{ height: '36px' }}
 									/>
@@ -245,14 +231,15 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 									className={data.idNumber ? 'mt-2' : 'mt-6'}
 									isBlurred={data.signatureFileHidden}
 									label="Signature">
-									<div
+									<img
 										className="mt-1"
+										src={data.signatureFile.source}
 										style={{
-											backgroundImage: `url(${data.signatureFile.source})`,
-											backgroundPosition: 'left center',
-											backgroundRepeat: 'no-repeat',
-											backgroundSize: 'contain',
+											filter: 'grayscale(100%)',
 											height: '38px',
+											maxWidth: '193px',
+											objectFit: 'contain',
+											objectPosition: 'top',
 										}}
 									/>
 								</DataItem>
@@ -260,14 +247,18 @@ export const PublicPreview: React.FC<PublicPreviewProps> = ({ className, data, o
 						</div>
 					</div>
 
-					{(hasAddress || data.issuedBy || data.documentNumber) && (
+					{(data.address || data.country || data.issuedBy || data.documentNumber) && (
 						<div className="flex mt-10">
-							{hasAddress && (
-								<DataItem className="w-1/2" isBlurred={data.addressHidden} label="Permanent Address">
-									{data.address}
-									{data.address && (middleAddressLine || data.country) && <br />}
-									{middleAddressLine}
-									{(data.address || middleAddressLine) && data.country && <br />}
+							{(data.address || data.country) && (
+								<DataItem className="w-1/2 break-words" isBlurred={data.addressHidden} label="Permanent Address">
+									<div style={{ maxHeight: '84px', overflow: 'hidden' }}>
+										{data.address
+											?.split(/\r?\n/)
+											?.slice(0, 3)
+											.map((line, index) => (
+												<div key={index}>{line}</div>
+											))}
+									</div>
 									{data.country}
 								</DataItem>
 							)}

--- a/src/components/nft-id/public-preview.tsx
+++ b/src/components/nft-id/public-preview.tsx
@@ -60,6 +60,10 @@ const ID_WIDTH = 712;
 
 const COLOR_OPTIONS = [
 	{
+		name: 'Rebus',
+		colors: ['#a7cfba', '#9fe0e0', '#2083DF', '#8A008A', '#33001E'],
+	},
+	{
 		name: 'Blue',
 		colors: ['#A8E0FF', '#7BC8FF', '#0295FF', '#0B0084', '#0B0084'],
 	},
@@ -70,10 +74,6 @@ const COLOR_OPTIONS = [
 	{
 		name: 'Pink',
 		colors: ['#EE8BF0', '#F24BF5', '#B34BF5', '#96005C', '#411000'],
-	},
-	{
-		name: 'Blue and Pink',
-		colors: ['#a7cfba', '#9fe0e0', '#2083DF', '#8A008A', '#33001E'],
 	},
 	{
 		name: 'Green',

--- a/src/types/nft-id.ts
+++ b/src/types/nft-id.ts
@@ -30,9 +30,6 @@ export type NftIdData = {
 	nationality?: string;
 	addressHidden?: boolean;
 	address?: string;
-	city?: string;
-	state?: string;
-	zipCode?: string;
 	country?: string;
 	idPhotoFileHidden?: boolean;
 	idPhotoFile?: Media;


### PR DESCRIPTION
- Add scripts dev:mainnet:local and dev:testnet:local to run those envs locally
- Add rounded borders to nft id nationality flag and transparency
- Add two more colors for nft id and make blue the default one
- Change nft id address input to text area and limit it to 3 lines + country line
- Add text shadow to nft id text
- Add greyscale filter to signature image for nft id

![Screen Shot 2022-11-04 at 7 06 43 AM](https://user-images.githubusercontent.com/21248862/199980789-7f59c2cf-0d26-4538-8b55-5beb67fc6a34.png)
![Screen Shot 2022-11-04 at 7 11 18 AM](https://user-images.githubusercontent.com/21248862/199980791-42e60fc4-d6c2-44d9-8906-3ebedc98a9da.png)
![Screen Shot 2022-11-04 at 7 39 49 AM](https://user-images.githubusercontent.com/21248862/199980766-a1e4e81f-bd60-4555-a28c-31d04473aa1d.png)
![Screen Shot 2022-11-04 at 8 39 51 AM](https://user-images.githubusercontent.com/21248862/199980770-3e5ea0c7-718e-4044-8983-2e2d1476ae34.png)
![Screen Shot 2022-11-04 at 8 55 23 AM](https://user-images.githubusercontent.com/21248862/199980774-0c428149-a4ae-43c3-90fb-88d6694dae0f.png)
