### PR TITLE
hotfix: handle all title cases for proposals

### DIFF
--- a/.env.testnet.local
+++ b/.env.testnet.local
@@ -1,5 +1,5 @@
 REACT_APP_CHAIN_ID=reb_3333-1
-REACT_APP_REST_URL=https://api.rebustestnet.com:1317
-REACT_APP_RPC_URL=https://api.rebustestnet.com:26657
-REACT_APP_METAMASK_URL=https://api.rebustestnet.com:8545
+REACT_APP_REST_URL=https://testnet.rebus.money:1317
+REACT_APP_RPC_URL=https://testnet.rebus.money:46657
+REACT_APP_METAMASK_URL=https://testnet.rebus.money:48545
 REACT_APP_CHAIN_NAME="Rebus Testnet"

--- a/src/pages/proposals/new-cards.tsx
+++ b/src/pages/proposals/new-cards.tsx
@@ -49,7 +49,7 @@ const NewCards: FunctionComponent<CardsProps> = ({ proposals }) => {
 									</p>
 								</div>
 								<div className="py-2 text-xl whitespace-nowrap overflow-hidden text-ellipsis">
-									{proposal.raw.content.value.title}
+									{proposal.title || proposal.content?.value?.title || proposal.content?.title}
 								</div>
 								<div className="flex justify-between">
 									<div className="py-2 text-white-mid">


### PR DESCRIPTION
This PR fixes a bug that handles the different possible shapes of proposal data which were causing the page to break and titles to not be displayed. 