### PR TITLE
Dev 438 improve responsiveness

### DIFF
--- a/src/components/common/collapse-menu.tsx
+++ b/src/components/common/collapse-menu.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent, useState } from 'react';
+import { Button, Menu, MenuItem } from '@material-ui/core';
+import { observer } from 'mobx-react-lite';
+import { NameType } from 'src/reducers/slices/stake/slices/delegate-dialog';
+
+export interface MenuItem {
+	name: string;
+	onClick: (name: NameType) => void;
+}
+
+interface CollapseMenuProps {
+	menuItems: MenuItem[];
+	menuTriggerLabel: string;
+}
+
+const CollapseMenu: FunctionComponent<CollapseMenuProps> = observer(({ menuItems, menuTriggerLabel }) => {
+	const [anchorEl, setAnchorEl] = useState<EventTarget | null>(null);
+
+	const handleClick = (event: React.SyntheticEvent) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
+
+	return (
+		<>
+			<Button
+				className="btn gradient-blue whitespace-nowrap"
+				variant="outlined"
+				onClick={(e: React.SyntheticEvent) => handleClick(e)}>
+				{menuTriggerLabel}
+			</Button>
+			<Menu anchorEl={anchorEl as Element} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+				{menuItems.map((menuItem: MenuItem) => (
+					<MenuItem
+						key={menuItem.name}
+						onClick={() => {
+							menuItem.onClick(menuItem.name as NameType);
+							handleClose();
+						}}>
+						{menuItem.name}
+					</MenuItem>
+				))}
+			</Menu>
+		</>
+	);
+});
+
+export default CollapseMenu;

--- a/src/components/insync/data-table/index.tsx
+++ b/src/components/insync/data-table/index.tsx
@@ -18,6 +18,7 @@ type DataTableProps<T = any> = {
 	minWidth?: string;
 	noData?: ReactElement;
 	tableRowClassName?: string;
+	mobileRowTriggerWidth?: number;
 };
 
 const getItemKey = (item: any) => item.id;
@@ -33,6 +34,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({
 	minWidth,
 	noData,
 	tableRowClassName,
+	mobileRowTriggerWidth,
 }) => {
 	const [sortState, setSortState] = useState<SortState>();
 	const { isMobileView } = useWindowSize();
@@ -58,6 +60,8 @@ const DataTable: FunctionComponent<DataTableProps> = ({
 	useEffect(() => {
 		scrollBackToTop();
 	}, [data, scrollBackToTop]);
+
+	const { windowSize } = useWindowSize();
 
 	const sortedData = useMemo(() => {
 		if (!sortState) {
@@ -123,12 +127,20 @@ const DataTable: FunctionComponent<DataTableProps> = ({
 	const showRows = !loading && sortedData.length > 0;
 	const otherElement = <div className="flex justify-center md:px-15 md:pb-5 mt-5">{loading ? loader : noData}</div>;
 
-	if (isMobileView) {
+	if ((mobileRowTriggerWidth && windowSize.width <= mobileRowTriggerWidth) || isMobileView) {
+		const formattedMobileColumns: ColumnDef[] = columnDefs.map(column => {
+			if (column.header === 'Action') {
+				return { ...column, align: 'flex-end' };
+			}
+
+			return column;
+		});
+
 		return (
 			<div>
 				{sortedData.map((item, index) => (
 					<TableMobileRow
-						columnDefs={columnDefs}
+						columnDefs={formattedMobileColumns}
 						data={sortedData[index]}
 						key={getItemKey(item)}
 						index={index}
@@ -172,8 +184,13 @@ const DataTable: FunctionComponent<DataTableProps> = ({
 
 const TableContainer = styled.div`
 	.list {
-		overflow-x: auto !important;
-		overflow-y: scroll !important;
+		padding-left: 60px;
+		padding-right: 60px;
+
+		@media (max-width: 968px) {
+			padding-left: 2px;
+			padding-right: 2px;
+		}
 
 		& > div {
 			position: relative;
@@ -181,17 +198,20 @@ const TableContainer = styled.div`
 	}
 
 	.list {
-		@media (min-width: 768px) {
+		@media (max-width: 968px) {
 			padding-bottom: 20px;
-			padding-left: 60px;
-			padding-right: 45px;
+			padding-left: 2px;
+			padding-right: 2px;
 		}
 	}
 
 	.table-header {
-		@media (min-width: 768px) {
-			margin-left: 60px;
-			margin-right: 60px;
+		margin-left: 60px;
+		margin-right: 60px;
+
+		@media (max-width: 968px) {
+			margin-left: 4px;
+			margin-right: 4px;
 		}
 	}
 `;

--- a/src/components/insync/data-table/table-header-cell.tsx
+++ b/src/components/insync/data-table/table-header-cell.tsx
@@ -2,6 +2,7 @@ import { Button } from '@material-ui/core';
 import React, { FunctionComponent } from 'react';
 import { ArrowDownwardRounded, ArrowUpwardRounded } from '@material-ui/icons';
 import { ColumnDef, SortState } from './types';
+import useWindowSize from 'src/hooks/use-window-size';
 
 type Props = {
 	align?: ColumnDef['align'];
@@ -26,10 +27,11 @@ const TableHeaderCell: FunctionComponent<Props> = ({
 	sortState,
 	width,
 }) => {
+	const { windowSize } = useWindowSize();
 	const style: React.CSSProperties = {
 		color: 'rgba(255,255,255,.6)',
 		fontFamily: 'Inter,ui-sans-serif,system-ui',
-		fontSize: '14px',
+		fontSize: windowSize.width < 968 ? '12px' : '14px',
 		height: '100%',
 		justifyContent: align,
 		gridColumn: `span ${width}`,

--- a/src/components/insync/data-table/types.ts
+++ b/src/components/insync/data-table/types.ts
@@ -21,5 +21,6 @@ export type ColumnDef<T = Record<string, any>> = {
 	header: string;
 	hideHeaderMobile?: boolean;
 	property: string;
+	screenWith?: number;
 	width: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24;
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -53,8 +53,8 @@ const Home = observer<HomeProps>(() => {
 			</Container>
 			<div className="flex flex-col flex-1">
 				<div className="flex flex-col flex-1">
-					<Heading className="md:px-15">
-						<div className="flex items-center mb-3 whitespace-nowrap">
+					<Heading className="">
+						<div className="flex items-center mb-3 whitespace-nowrap md-sm:px-15 md-sm:mx-0 mx-auto">
 							<TabText className={active === 2 ? 'active' : ''} onClick={() => setActive(2)}>
 								{variables[lang]['staked_validators']}
 							</TabText>
@@ -118,7 +118,7 @@ const TabText = styled.p`
 		color: #ffffff;
 	}
 
-	@media (max-width: 769px) {
+	@media (max-width: 830px) {
 		font-size: 18px;
 	}
 

--- a/src/pages/home/token-details/index.tsx
+++ b/src/pages/home/token-details/index.tsx
@@ -59,7 +59,7 @@ const TokenDetails = observer<TokenDetailsProps>(props => {
 	const unstakedInProgress = unBondingDelegationsQuery.isFetching;
 
 	return (
-		<div className="flex flex-1 flex-col items-center justify-center md:flex-row md:items-start md:justify-start">
+		<div className="flex flex-1 flex-wrap flex-col items-center justify-center md:flex-row md:items-start md:justify-start">
 			<ChipInfo>
 				<Label>{langVariables['available_tokens']}</Label>
 				<Chip>

--- a/src/pages/stake/index.tsx
+++ b/src/pages/stake/index.tsx
@@ -66,11 +66,11 @@ const TabText = styled.p`
 	font-size: 24px;
 	color: #ffffff80;
 
-	&.actife {
+	&.active {
 		color: #ffffff;
 	}
 
-	@media (max-width: 769px) {
+	@media (max-width: 830px) {
 		font-size: 18px;
 	}
 

--- a/src/reducers/slices/stake/slices/delegate-dialog.ts
+++ b/src/reducers/slices/stake/slices/delegate-dialog.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-type NameType = 'Stake' | 'Delegate' | 'Undelegate' | 'Redelegate' | '';
+export type NameType = 'Stake' | 'Delegate' | 'Undelegate' | 'Redelegate' | '';
 
-type ShowDelegateDialog = {
+export type ShowDelegateDialog = {
 	name: NameType;
 	validatorAddress?: string;
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -253,6 +253,10 @@ module.exports = {
 				fontSize: ['responsive'],
 				zIndex: ['hover'],
 			},
+			screens: {
+				'md-sm': '958px',
+				...defaultTheme.screens,
+			},
 		},
 	},
 	variants: {


### PR DESCRIPTION
This PR makes the dataTable component more responsive especially the instance on /stake page. Added a new collapsable menu button to the action cell render and the table's mobile row is now implemented on a slightly larger width. 


Screenshots: 

![Screenshot 2022-12-19 at 8 46 47 AM](https://user-images.githubusercontent.com/117384613/208440943-56b15a9c-ca7e-4426-8c33-075f604fb917.png)
![Screenshot 2022-12-20 at 10 44 35 AM](https://user-images.githubusercontent.com/117384613/208707223-90288887-116a-41a3-9635-6182bb77a094.png)
![Screenshot 2022-12-19 at 9 04 51 AM](https://user-images.githubusercontent.com/117384613/208443528-a9fc1b0a-02ef-4ff7-8d2a-2a5abc1d0cea.png)

