### PR TITLE
bugfix(Dev-587): fix vote success modal header

### DIFF
--- a/src/reducers/slices/stake/slices/delegate-dialog.ts
+++ b/src/reducers/slices/stake/slices/delegate-dialog.ts
@@ -22,6 +22,7 @@ export const delegateDialogSlice = createSlice({
 		hideDelegateDialog: state => ({
 			...state,
 			open: false,
+			name: '',
 		}),
 		showDelegateDialog: (state, action: PayloadAction<ShowDelegateDialog>) => ({
 			open: true,


### PR DESCRIPTION
Update action call to reset modal name on close, fixes the modal header after voting
![Screenshot 2023-05-02 at 2 47 50 PM](https://user-images.githubusercontent.com/117384613/235799245-dd1dd019-c691-482e-bbe6-3fc973f0f93a.png)
