### PR TITLE
DEV-672 pages redesign with light/dark mode

### DIFF
--- a/src/components/common/checkbox.tsx
+++ b/src/components/common/checkbox.tsx
@@ -3,19 +3,22 @@ import styled from 'styled-components';
 
 interface CheckboxProps {
 	label: string;
+	labelStyle?: React.CSSProperties;
 	style?: React.CSSProperties;
+	onChange: () => void;
 }
 
-const Checkbox: React.FC<CheckboxProps> = ({ label, style }) => {
+const Checkbox: React.FC<CheckboxProps> = ({ label, style, labelStyle, onChange }) => {
 	const [checked, setChecked] = useState(false);
 
 	const handleCheckboxChange = () => {
 		setChecked(!checked);
+		onChange();
 	};
 
 	return (
 		<CheckboxStyled style={style}>
-			<label className={`checkbox-label ${checked ? 'checked' : ''}`}>
+			<label className={`checkbox-label ${checked ? 'checked' : ''}`} style={labelStyle}>
 				<input type="checkbox" checked={checked} onChange={handleCheckboxChange} />
 				<span className="checkmark">&#10003;</span>
 				{label}
@@ -43,6 +46,7 @@ const CheckboxStyled = styled.div`
 			width: 24px;
 			height: 24px;
 			border: 3px solid ${props => props.theme.gray.light};
+			font-size: 24px;
 			background-color: transparent;
 			margin-right: 10px;
 			display: flex;

--- a/src/components/common/input/date-input.tsx
+++ b/src/components/common/input/date-input.tsx
@@ -1,55 +1,45 @@
 import classNames from 'classnames';
-import React, { useCallback } from 'react';
-import { TextInput } from './text-input';
-import styled from '@emotion/styled';
-import DatePicker from '@mui/lab/DatePicker';
-import { TextFieldProps } from '@mui/material';
+import React, { useState, ChangeEventHandler } from 'react';
+import { TextInput, TextInputProps } from './text-input';
+import { useTheme } from 'styled-components';
 
 export type DateInputProps = {
 	className?: string;
-	onChange: (name: string, value: string) => void;
+	onRawChange: ChangeEventHandler<HTMLInputElement>;
 	name?: string;
 	value?: string;
 };
 
 const DATE_FORMAT = 'MM/DD/YYYY';
 
-const TextFieldComponent: React.ComponentType<React.PropsWithChildren<TextFieldProps>> = ({
-	onChange,
-	InputProps,
-	value,
-}) => {
-	return (
-		<div className="relative">
-			<TextInput onRawChange={onChange} placeholder={DATE_FORMAT} value={(value as string) || ''} />
-			<EndAdormentContainer className="absolute right-0 top-5">{InputProps?.endAdornment}</EndAdormentContainer>
-		</div>
-	);
-};
-
 export const DateInput: React.FC<React.PropsWithChildren<DateInputProps>> = ({
 	className,
-	onChange,
+	onRawChange,
 	name = '',
 	value,
 }) => {
-	const onDateChange = useCallback((date: any) => onChange(name, date?.format(DATE_FORMAT) || ''), [name, onChange]);
+	const theme = useTheme();
+	const [formattedValue, setFormattedValue] = useState(value || '');
+
+	const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		let inputValue = e.target.value.replace(/\D/g, '');
+		inputValue = inputValue.replace(/(\d{2})(\d{2})(\d{4})/, '$1/$2/$3');
+
+		if (inputValue.length <= 10) {
+			setFormattedValue(inputValue);
+			onRawChange(e);
+		}
+	};
 
 	return (
 		<div className={classNames(className, 'flex flex-1 w-full')}>
-			<DatePicker
-				disableFuture
-				format={DATE_FORMAT}
-				value={value || null}
-				onChange={onDateChange}
-				TextFieldComponent={TextFieldComponent}
+			<TextInput
+				onRawChange={onInputChange}
+				name={name}
+				placeholder={DATE_FORMAT}
+				value={formattedValue}
+				style={{ background: theme.gray.lightest, color: theme.text }}
 			/>
 		</div>
 	);
 };
-
-const EndAdormentContainer = styled.div`
-	svg {
-		color: white;
-	}
-`;

--- a/src/components/common/input/file-input.tsx
+++ b/src/components/common/input/file-input.tsx
@@ -1,10 +1,11 @@
-import styled from '@emotion/styled';
 import classNames from 'classnames';
 import React, { MouseEventHandler, useRef } from 'react';
 import { ReactSVG } from 'react-svg';
 import { Media } from 'src/types/nft-id';
 import { Button } from '../button';
 import { TextInput } from './text-input';
+import styled, { useTheme } from 'styled-components';
+import TextField from 'src/components/insync/text-field/text-field';
 
 export type FileInputProps = {
 	className?: string;
@@ -26,6 +27,7 @@ export const FileInput: React.FC<React.PropsWithChildren<FileInputProps>> = ({
 	value,
 }) => {
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const theme = useTheme();
 
 	const onStartUpload: MouseEventHandler<HTMLButtonElement> = e => {
 		if (fileInputRef.current) {
@@ -55,10 +57,11 @@ export const FileInput: React.FC<React.PropsWithChildren<FileInputProps>> = ({
 	return (
 		<div className={classNames(className, 'flex')}>
 			<div
-				className="bg-gray-1 rounded-2lg flex-shrink-0"
+				className="rounded-2lg flex-shrink-0"
 				style={{
 					height: '115px',
 					width: '100px',
+					background: theme.gray.lightest,
 				}}>
 				<div
 					style={{
@@ -84,6 +87,7 @@ export const FileInput: React.FC<React.PropsWithChildren<FileInputProps>> = ({
 							placeholder="Upload File"
 							readonly
 							value={value?.name || ''}
+							style={{ background: theme.gray.lightest, color: theme.text }}
 						/>
 						{value && (
 							<button className="absolute right-1 top-2" onClick={() => onChange(name, undefined)}>

--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -7,6 +7,7 @@ import { SelectInput, SelectInputProps } from './select-input';
 import { TextInput, TextInputProps } from './text-input';
 import { Media } from 'src/types/nft-id';
 import { TextareaInput, TextareaInputProps } from './textarea-input';
+import styled, { useTheme } from 'styled-components';
 
 export enum InputTypes {
 	Date = 'date',
@@ -18,7 +19,7 @@ export enum InputTypes {
 
 export interface InputProps
 	extends Omit<TextInputProps, 'onChange' | 'onRawChange' | 'onClick' | 'value'>,
-		Omit<DateInputProps, 'onChange' | 'value'>,
+		Omit<DateInputProps, 'onRawChange' | 'value'>,
 		Omit<FileInputProps, 'onChange' | 'value'>,
 		Omit<SelectInputProps, 'onChange' | 'value'>,
 		Omit<TextareaInputProps, 'onChange' | 'onRawChange' | 'onClick' | 'value'> {
@@ -27,7 +28,7 @@ export interface InputProps
 	label?: string;
 	onChange?:
 		| TextInputProps['onChange']
-		| DateInputProps['onChange']
+		| DateInputProps['onRawChange']
 		| FileInputProps['onChange']
 		| SelectInputProps['onChange']
 		| TextareaInputProps['onChange'];
@@ -59,11 +60,16 @@ export const Input: React.FC<React.PropsWithChildren<InputProps>> = ({
 	width = 'w-full',
 }) => {
 	let content = null;
+	const theme = useTheme();
 
 	switch (type) {
 		case InputTypes.Date:
 			content = (
-				<DateInput onChange={onChange as DateInputProps['onChange']} name={name} value={value as string | undefined} />
+				<DateInput
+					onRawChange={onChange as DateInputProps['onRawChange']}
+					name={name}
+					value={value as string | undefined}
+				/>
 			);
 			break;
 		case InputTypes.File:
@@ -97,6 +103,7 @@ export const Input: React.FC<React.PropsWithChildren<InputProps>> = ({
 					placeholder={placeholder}
 					rows={rows}
 					value={value as string | undefined}
+					style={{ background: theme.gray.lightest, color: theme.text }}
 				/>
 			);
 			break;
@@ -107,6 +114,7 @@ export const Input: React.FC<React.PropsWithChildren<InputProps>> = ({
 					name={name}
 					placeholder={placeholder}
 					value={value as string | undefined}
+					style={{ background: theme.gray.lightest, color: theme.text }}
 				/>
 			);
 			break;
@@ -116,14 +124,20 @@ export const Input: React.FC<React.PropsWithChildren<InputProps>> = ({
 		<div className={classNames(className, width)} style={style}>
 			{label && (
 				<div className="flex items-center mb-2">
-					<label className="block text-xs font-bold gray-6 opacity-60 uppercase">{label}</label>
+					<LabelStyled className="block text-xs font-bold gray-6 opacity-60 uppercase">{label}</LabelStyled>
 					<button className="ml-2" onClick={() => onVisibilityChange(name, !hide)}>
-						<ReactSVG src={hide ? '/public/assets/icons/hidden.svg' : '/public/assets/icons/visible.svg'} />
+						<ReactSVG
+							src={hide ? '/public/assets/icons/hidden.svg' : '/public/assets/icons/visible.svg'}
+							style={{ filter: theme.text === '#FFFFFF' ? 'none' : 'invert(1)' }}
+						/>
 					</button>
 				</div>
 			)}
-
 			<div>{content}</div>
 		</div>
 	);
 };
+
+const LabelStyled = styled.label`
+	color: ${props => props.theme.text};
+`;

--- a/src/components/common/input/select-input.tsx
+++ b/src/components/common/input/select-input.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import styled from '@emotion/styled';
+import { DefaultTheme, useTheme } from 'styled-components';
 import Select, { ActionMeta, SingleValue, StylesConfig } from 'react-select';
 
 export type Option = {
@@ -21,30 +22,37 @@ export type SelectInputProps = {
 	value?: string;
 };
 
-const styles: StylesConfig<Option, false, GroupedOption> = {
-	clearIndicator: styles => ({ ...styles, color: 'white !important', cursor: 'pointer !important' }),
+function hexToRgb(hex: string, alpha: number): string {
+	const r = parseInt(hex.slice(1, 3), 16);
+	const g = parseInt(hex.slice(3, 5), 16);
+	const b = parseInt(hex.slice(5, 7), 16);
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+const styles = (theme: DefaultTheme): StylesConfig<Option, false, GroupedOption> => ({
+	clearIndicator: styles => ({ ...styles, color: theme.text, cursor: 'pointer !important' }),
 	control: styles => ({
 		...styles,
-		backgroundColor: 'rgba(255, 255, 255, 0.1)',
+		backgroundColor: theme.gray.lightest,
 		border: 'none',
 		borderRadius: 10,
 		boxShadow: 'none',
 		cursor: 'text',
 	}),
-	dropdownIndicator: styles => ({ ...styles, color: 'white !important', cursor: 'pointer !important' }),
+	dropdownIndicator: styles => ({ ...styles, color: theme.text, cursor: 'pointer !important' }),
 	option: (styles, { isFocused, isSelected }) => {
 		return {
 			...styles,
-			backgroundColor: isFocused || isSelected ? 'rgba(255, 255, 255, 0.1) !important' : 'transparent !important',
+			backgroundColor: isFocused || isSelected ? theme.gray.lightest : 'transparent !important',
 			cursor: 'pointer !important',
 		};
 	},
-	input: styles => ({ ...styles, color: 'white !important' }),
-	menu: styles => ({ ...styles, backgroundColor: '#2D3D77' }),
-	placeholder: styles => ({ ...styles, color: 'rgba(255, 255, 255, 0.5)' }),
-	singleValue: (styles, { data }) => ({ ...styles, color: 'white !important' }),
+	input: styles => ({ ...styles, color: theme.text }),
+	menu: styles => ({ ...styles, backgroundColor: theme.gray.lighter }),
+	placeholder: styles => ({ ...styles, color: `${hexToRgb(theme.text, 0.5)}` }),
+	singleValue: (styles, { data }) => ({ ...styles, color: theme.text }),
 	valueContainer: styles => ({ ...styles, padding: '4px 12px' }),
-};
+});
 
 const formatGroupLabel = (data: GroupedOption) => (
 	<div className="flex items-center">
@@ -93,6 +101,9 @@ export const SelectInput: React.FC<React.PropsWithChildren<SelectInputProps>> = 
 		[name, onChange]
 	);
 
+	const theme = useTheme();
+	const themedStyles = styles(theme);
+
 	return (
 		<Select<Option, false, GroupedOption>
 			className={className}
@@ -103,7 +114,7 @@ export const SelectInput: React.FC<React.PropsWithChildren<SelectInputProps>> = 
 			onChange={innerOnChange}
 			options={options}
 			placeholder={placeholder}
-			styles={styles}
+			styles={themedStyles}
 			value={selectedOption}
 		/>
 	);

--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import TextField from '../insync/text-field/textField';
+import TextField from '../insync/text-field/text-field';
 import { Button } from './button';
 import Checkbox from './checkbox';
 
@@ -9,12 +9,15 @@ interface ModalProps {
 	subtitle: string;
 	textfields: Array<{
 		label: string;
-		assistiveText: string;
-		disabled: boolean;
-		error: boolean;
-		errorMessage: string;
+		value: string;
+		onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+		assistiveText?: string;
+		placeholder?: string;
+		disabled?: boolean;
+		errorMessage?: string;
+		buttonText?: string;
 	}>;
-	checkboxes: Array<{ label: string }>;
+	checkboxes: Array<{ label: string; onChange: () => void }>;
 	onClose?: () => void;
 	onConfirm?: () => void;
 }
@@ -49,17 +52,20 @@ const Modal: React.FC<ModalProps> = ({ title, subtitle, textfields, checkboxes, 
 					<TextField
 						key={index}
 						label={textfield.label}
+						value={textfield.value}
+						onChange={textfield.onChange}
 						assistiveText={textfield.assistiveText}
+						placeholder={textfield.placeholder}
 						disabled={textfield.disabled}
-						error={textfield.error}
 						errorMessage={textfield.errorMessage}
+						buttonText={textfield.buttonText}
 					/>
 				))}
 				<ModalSubHeader>
 					<h6>{subtitle}</h6>
 				</ModalSubHeader>
 				{checkboxes.map((checkbox, index) => (
-					<Checkbox key={index} label={checkbox.label} style={{ paddingTop: '10px' }} />
+					<Checkbox key={index} label={checkbox.label} onChange={checkbox.onChange} style={{ paddingTop: '10px' }} />
 				))}
 				<ModalFooter>
 					<Button backgroundStyle={'ghost'} onClick={closeModal}>

--- a/src/components/connect-account-button.tsx
+++ b/src/components/connect-account-button.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import * as React from 'react';
 import { Button } from 'src/components/common/button';
 import { Text } from 'src/components/texts';
@@ -28,19 +28,8 @@ export function ConnectAccountButton(props: React.HTMLAttributes<HTMLButtonEleme
 	);
 }
 
-const ConnectAccountButtonWrapper = styled.button`
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
-	padding: 12px 4px;
-
-	@media (min-width: 768px) {
-		padding: 14px 4px;
-	}
-`;
-
 const WalletImg = styled.img`
 	width: 1.25rem;
 	height: 1.25rem;
+	margin-top: 2px;
 `;

--- a/src/components/insync/text-field/text-field.tsx
+++ b/src/components/insync/text-field/text-field.tsx
@@ -4,13 +4,31 @@ import classnames from 'classnames';
 
 interface TextFieldProps {
 	label: string;
-	assistiveText: string;
-	disabled: boolean;
-	error: boolean;
-	errorMessage: string;
+	value: string;
+	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	type?: string;
+	assistiveText?: string;
+	placeholder?: string;
+	disabled?: boolean;
+	errorMessage?: string;
+	buttonText?: string;
+	onButtonClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+	disabledButton?: boolean;
 }
 
-const TextField: React.FC<TextFieldProps> = ({ label, assistiveText, disabled, error, errorMessage }) => {
+const TextField: React.FC<TextFieldProps> = ({
+	label,
+	value,
+	onChange,
+	type = 'text',
+	assistiveText = '',
+	placeholder = '',
+	disabled = false,
+	errorMessage = '',
+	buttonText = '',
+	onButtonClick = () => null,
+	disabledButton = false,
+}) => {
 	const [isHovered, setHovered] = useState(false);
 	const [isActive, setActive] = useState(false);
 
@@ -34,29 +52,31 @@ const TextField: React.FC<TextFieldProps> = ({ label, assistiveText, disabled, e
 		<TextFieldStyled>
 			<label className="label">{label}</label>
 			<div
-				className={classnames(
-					'input-wrapper',
-					{ hovered: isHovered },
-					{ active: isActive },
-					{ error: error },
-					{ disabled: disabled }
-				)}>
+				className={classnames('input-wrapper', { hovered: isHovered }, { active: isActive }, { disabled: disabled })}>
 				<span className={`dot ${disabled ? 'disabled' : ''}`} />
 				<input
-					type="text"
+					type={type}
+					placeholder={placeholder}
 					onMouseEnter={handleMouseEnter}
 					onMouseLeave={handleMouseLeave}
 					onMouseDown={handleMouseDown}
 					onMouseUp={handleMouseUp}
 					disabled={disabled}
+					value={value}
+					onChange={onChange}
 				/>
 				<span className={`dot ${disabled ? 'disabled' : ''}`} />
-				<button className={`max-button ${disabled ? 'disabled' : ''}`} disabled={disabled}>
-					Max
-				</button>
+				{buttonText && (
+					<button
+						className={`max-button ${disabled || disabledButton ? 'disabled' : ''}`}
+						disabled={disabled || disabledButton}
+						onClick={onButtonClick}>
+						{buttonText}
+					</button>
+				)}
 			</div>
 			<div className="assistive-text">{assistiveText}</div>
-			{error && <div className="error-message"> {errorMessage} </div>}
+			{errorMessage && <div className="error-message"> {errorMessage} </div>}
 		</TextFieldStyled>
 	);
 };
@@ -139,7 +159,7 @@ const TextFieldStyled = styled.div`
 			background-color: transparent;
 			border: none;
 			outline: none;
-			color: ${props => props.theme.gray.dark};
+			color: ${props => props.theme.text};
 			position: relative;
 		}
 

--- a/src/components/layouts/containers.tsx
+++ b/src/components/layouts/containers.tsx
@@ -1,8 +1,9 @@
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import { colorPrimary } from 'src/emotion-styles/colors';
 import { onLgWidth, on2XlWidth } from 'src/emotion-styles/media-queries';
 
 export const FullScreenContainer = styled.div`
+	background-color: ${props => props.theme.background};
 	width: 100%;
 	height: 100%;
 `;

--- a/src/components/layouts/route-wrapper.tsx
+++ b/src/components/layouts/route-wrapper.tsx
@@ -3,6 +3,7 @@ import { useMatch } from 'react-router-dom';
 import { ROUTES } from 'src/constants/routes';
 import useWindowSize from 'src/hooks/use-window-size';
 import { Sidebar } from './sidebar';
+import styled from 'styled-components';
 
 export const RouteWrapper: FunctionComponent<React.PropsWithChildren<unknown>> = ({ children }) => {
 	const { isMobileView } = useWindowSize();
@@ -11,11 +12,15 @@ export const RouteWrapper: FunctionComponent<React.PropsWithChildren<unknown>> =
 	return (
 		<div className="h-fit md:h-full w-full flex">
 			{!isNftIdViewRoute && <Sidebar />}
-			<div
+			<BackgroundStyled
 				className="h-fit md:h-full w-full flex justify-center text-white-high"
 				style={{ maxWidth: isMobileView ? undefined : 'calc(100% - 206px)', overflowX: 'auto' }}>
 				{children}
-			</div>
+			</BackgroundStyled>
 		</div>
 	);
 };
+
+const BackgroundStyled = styled.div`
+	background: ${props => props.theme.background};
+`;

--- a/src/components/nft-id/color-picker.tsx
+++ b/src/components/nft-id/color-picker.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import React from 'react';
 import { Theme } from 'src/types/nft-id';
+import { styled } from 'styled-components';
+import { Button } from '../common/button';
 
 type ColorOption = {
 	name: string;
@@ -23,29 +25,38 @@ export const ColorPicker: React.FC<React.PropsWithChildren<ColorPickerProps>> = 
 	value,
 }) => {
 	return (
-		<div className={classNames(className, 'relative')}>
+		<ColorPickerStyled className={classNames(className, 'relative')}>
 			<h5 className="whitespace-nowrap mb-6">Color Theme</h5>
 
 			<div className="flex items-center flex-wrap">
 				{options.map(option => (
-					<div
-						className={classNames(
-							'flex items-center bg-black bg-opacity-30 py-2.5 px-3.5 cursor-pointer mr-2.5 mb-2.5 border-2 border-opacity-30',
-							value.name === option.name && 'border-white',
-							value.name !== option.name && 'border-transparent'
-						)}
+					<Button
 						key={option.name}
+						backgroundStyle="secondary"
 						onClick={() => onChange(option)}
-						style={{ borderRadius: '45px' }}>
-						<div
-							className="flex items-center justify-center rounded-full"
-							style={{ background: getLinearGradient(option.colors), height: '32px', width: '32px' }}>
-							{value.name === option.name && <img src="/public/assets/icons/checkmark.svg" />}
-						</div>
-						<div className="white font-bold text-lg ml-2">{option.name}</div>
-					</div>
+						style={{ margin: '2px', minWidth: '150px', display: 'flex', alignItems: 'center', position: 'relative' }}>
+						{
+							<>
+								<div
+									className="flex items-center justify-center rounded-full"
+									style={{
+										background: getLinearGradient(option.colors),
+										height: '32px',
+										width: '32px',
+										position: 'absolute',
+										left: '32px',
+									}}
+								/>
+								<span style={{ position: 'absolute', left: '70px' }}>{option.name}</span>
+							</>
+						}
+					</Button>
 				))}
 			</div>
-		</div>
+		</ColorPickerStyled>
 	);
 };
+
+const ColorPickerStyled = styled.div`
+	color: ${props => props.theme.text};
+`;

--- a/src/components/nft-id/id-form.tsx
+++ b/src/components/nft-id/id-form.tsx
@@ -9,6 +9,7 @@ import { Button } from '../common/button';
 import { Loader } from '../common/loader';
 import ConfirmDialog from 'src/pages/stake/delegate-dialog/confirm-dialog';
 import { config } from 'src/config-insync';
+import styled from 'styled-components';
 import {
 	COSMIC_BODIES_OPTIONS,
 	EXTRA_EARTH_LOCATIONS,
@@ -206,7 +207,7 @@ export const IdForm: React.FC<React.PropsWithChildren<IdFormProps>> = ({
 	];
 
 	return (
-		<div className={className} style={{ maxWidth: '580px' }}>
+		<IdFormStyled className={className} style={{ maxWidth: '580px' }}>
 			<div className="mb-6 w-full flex items-center">
 				<h5 className="whitespace-nowrap">Identification Details</h5>
 				<div className="flex items-center ml-3">
@@ -244,6 +245,10 @@ export const IdForm: React.FC<React.PropsWithChildren<IdFormProps>> = ({
 				onConfirm={onConfirm}
 				title="Confirm Minting of NFT ID"
 			/>
-		</div>
+		</IdFormStyled>
 	);
 };
+
+const IdFormStyled = styled.div`
+	color: ${props => props.theme.text};
+`;

--- a/src/components/nft-id/id-preview.tsx
+++ b/src/components/nft-id/id-preview.tsx
@@ -6,6 +6,7 @@ import { renderToImage } from 'src/utils/nft-id';
 import { BigLoader } from '../common/loader';
 import classNames from 'classnames';
 import { ActiveDot } from './active-dot';
+import { styled } from 'styled-components';
 
 type IdPreviewProps = {
 	className?: string;
@@ -114,7 +115,7 @@ export const IdPreview: React.FC<React.PropsWithChildren<IdPreviewProps>> = ({
 	]);
 
 	return (
-		<div className={className}>
+		<IdPreviewStyled className={className}>
 			{(title || titleSuffix) && (
 				<div className="flex items-center mb-4 flex-wrap">
 					<h5 className={classNames('whitespace-nowrap mb-2', titleClassName)}>{title}</h5>
@@ -160,6 +161,10 @@ export const IdPreview: React.FC<React.PropsWithChildren<IdPreviewProps>> = ({
 					/>
 				)}
 			</div>
-		</div>
+		</IdPreviewStyled>
 	);
 };
+
+const IdPreviewStyled = styled.div`
+	color: ${props => props.theme.text};
+`;

--- a/src/components/nft-id/private-view.tsx
+++ b/src/components/nft-id/private-view.tsx
@@ -32,6 +32,8 @@ import { getIpfsHttpsUrl, getIpfsId } from 'src/utils/ipfs';
 import InputDialog from 'src/pages/stake/delegate-dialog/input-dialog';
 import { ENCRYPTION_KEY_KEY } from 'src/stores/wallet';
 import { StatusChangeButton } from './status-change-button';
+import styled from 'styled-components';
+import { Margin } from '@mui/icons-material';
 
 const ipfs = new IPFS(env('NFT_STORAGE_TOKEN'));
 
@@ -517,7 +519,11 @@ const PrivateView: FunctionComponent<React.PropsWithChildren<unknown>> = observe
 							titleSuffix={
 								<div className="whitespace-nowrap">
 									<Tooltip title="Open public view of NFT ID in another tab" arrow>
-										<Button ref={publicViewTooltipRef} backgroundStyle="secondary" onClick={goToPublicPreviewLink}>
+										<Button
+											ref={publicViewTooltipRef}
+											backgroundStyle="secondary"
+											onClick={goToPublicPreviewLink}
+											style={{ margin: '8px' }}>
 											See Public View
 										</Button>
 									</Tooltip>
@@ -533,7 +539,7 @@ const PrivateView: FunctionComponent<React.PropsWithChildren<unknown>> = observe
 											backgroundStyle="secondary"
 											disabled={isDecryptingPrivateImage || isSaving || isFetchingPrivateImage}
 											onClick={isDecrypted ? encryptPrivateImage : decryptPrivateImage}
-											style={{ marginLeft: '8px' }}>
+											style={{ margin: '8px' }}>
 											{isDecrypted ? 'Encrypt ID' : 'Decrypt ID'}
 										</Button>
 									</Tooltip>
@@ -547,7 +553,7 @@ const PrivateView: FunctionComponent<React.PropsWithChildren<unknown>> = observe
 												backgroundStyle="secondary"
 												disabled={isSaving}
 												onClick={openClearEncryptionDialog}
-												style={{ marginLeft: '8px' }}>
+												style={{ margin: '8px' }}>
 												Clear Encryption Key
 											</Button>
 										</Tooltip>
@@ -600,3 +606,7 @@ const PrivateView: FunctionComponent<React.PropsWithChildren<unknown>> = observe
 });
 
 export { PrivateView };
+
+const NFTIdStyled = styled.div`
+	color: ${props => props.theme.text}'
+`;

--- a/src/components/nft-id/question.tsx
+++ b/src/components/nft-id/question.tsx
@@ -3,6 +3,9 @@ import pickBy from 'lodash-es/pickBy';
 import identity from 'lodash-es/identity';
 import { Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel, Radio, RadioGroup } from '@mui/material';
 import { Question as QuestionData, UserAnswer } from 'src/stores/questions/types';
+import styled, { useTheme } from 'styled-components';
+import { Text } from '../texts';
+import { Button } from '../common/button';
 
 type QuestionProps = {
 	question: QuestionData;
@@ -13,14 +16,6 @@ type QuestionProps = {
 
 type CheckboxStateProps = {
 	[key: number]: boolean;
-};
-
-const formControlStyles = {
-	border: '2px solid #FFFFFF30',
-	background: '#00000030',
-	borderRadius: '10px',
-	display: 'flex',
-	margin: '2px 0px',
 };
 
 export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>> = ({
@@ -36,6 +31,8 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setAnswer(parseInt(event.target.value));
 	};
+
+	const theme = useTheme();
 
 	const handleMultiSelectChange = useCallback(
 		(id: number) => (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -82,16 +79,16 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 					style={{
 						fontSize: '32px',
 						lineHeight: '32px',
-						color: '#FFFFFF',
+						color: theme.text,
 						margin: '24px 32px',
 						textAlign: 'center',
 					}}
 					id={`question-${question.id}-label`}>
 					{question.prompt}
 				</FormLabel>
-				<p className="sub-text text-white-mid text-base text-center mb-6">
+				<TextStyled className="sub-text text-base text-center mb-6">
 					{question.isMultipleChoice ? 'Select at least one' : 'Select only one.'}
-				</p>
+				</TextStyled>
 
 				<div className="flex flex-col">
 					{!question.isMultipleChoice && (
@@ -99,11 +96,18 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 							{question.answers.map(answerOption => (
 								<FormControlLabel
 									key={answerOption.id}
-									style={formControlStyles}
+									style={{
+										border: `2px solid ${theme.text}`,
+										color: theme.text,
+										background: theme.background,
+										borderRadius: '10px',
+										display: 'flex',
+										margin: '2px 0px',
+									}}
 									control={
 										<Radio
 											style={{
-												color: '#FFFFFF',
+												color: theme.text,
 											}}
 										/>
 									}
@@ -118,7 +122,14 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 							{question.answers.map(answerOption => (
 								<FormControlLabel
 									key={answerOption.id}
-									style={formControlStyles}
+									style={{
+										border: `2px solid ${theme.text}`,
+										color: theme.text,
+										background: theme.background,
+										borderRadius: '10px',
+										display: 'flex',
+										margin: '2px 0px',
+									}}
 									control={
 										<Checkbox
 											checked={multiSelectAnswer[answerOption.id] || false}
@@ -127,7 +138,7 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 											style={{
 												borderRadius: '2px',
 												borderWidth: '1px',
-												color: '#FFFFFF',
+												color: theme.text,
 											}}
 										/>
 									}
@@ -139,20 +150,34 @@ export const Question: FunctionComponent<React.PropsWithChildren<QuestionProps>>
 				</div>
 			</FormControl>
 			<div className="buttons-wrapper flex justify-between items-center mt-6">
-				<button
-					className="bg-blue1 py-2 px-3.75 w-24 rounded-lg focus:outline-none disabled:bg-white-disabled disabled:opacity-50"
+				<Button
+					backgroundStyle={'secondary'}
 					onClick={previousClickHandler}
-					disabled={currentStep === 1}>
+					disabled={currentStep === 1}
+					style={{ minWidth: '125px' }}>
 					Previous
-				</button>
-				<p>{`${currentStep} of 5`}</p>
-				<button
-					disabled={isDisabled}
+				</Button>
+				<TextStyled>{`${currentStep} of 5`}</TextStyled>
+				<Button
+					backgroundStyle={'secondary'}
 					onClick={handleNextQuestionClick}
-					className="bg-blue1 py-2 px-3.75 w-24 rounded-lg disabled:bg-white-disabled disabled:opacity-50">
+					disabled={isDisabled}
+					style={{ minWidth: '125px' }}>
 					Next
-				</button>
+				</Button>
 			</div>
 		</div>
 	);
+};
+
+const TextStyled = styled.p`
+	color: ${props => props.theme.text};
+`;
+
+const formControlStyles = {
+	border: '2px solid #FFFFFF30',
+	background: '#00000030',
+	borderRadius: '10px',
+	display: 'flex',
+	margin: '2px 0px',
 };

--- a/src/dialogs/convert.tsx
+++ b/src/dialogs/convert.tsx
@@ -302,11 +302,8 @@ export const ConvertDialog = wrapBaseDialog(
 										<Button
 											style={{
 												borderRadius: '12px !important',
-												fontSize: '11px',
-												marginBottom: '3px',
-												marginLeft: '6px',
+												margin: '6px',
 												minWidth: '0',
-												padding: '2px 8px',
 											}}
 											onClick={e => {
 												e.preventDefault();

--- a/src/dialogs/transfer.tsx
+++ b/src/dialogs/transfer.tsx
@@ -233,11 +233,8 @@ export const TransferDialog = wrapBaseDialog(
 										<Button
 											style={{
 												borderRadius: '12px !important',
-												fontSize: '11px',
-												marginBottom: '3px',
-												marginLeft: '6px',
+												margin: '6px',
 												minWidth: '0',
-												padding: '2px 8px',
 											}}
 											onClick={e => {
 												e.preventDefault();

--- a/src/pages/ibc-transfer/address-input.tsx
+++ b/src/pages/ibc-transfer/address-input.tsx
@@ -2,6 +2,9 @@ import classNames from 'classnames';
 import React, { ChangeEventHandler, useState } from 'react';
 import { AmountInput } from 'src/components/form/inputs';
 import { Button } from 'src/components/common/button';
+import styled from 'styled-components';
+import TextField from 'src/components/insync/text-field/text-field';
+import Checkbox from 'src/components/common/checkbox';
 
 type Props = {
 	address: string;
@@ -32,18 +35,15 @@ export const AddressInput = ({
 	const [didVerifyWithdrawRisks, setDidVerifyWithdrawRisks] = useState(false);
 
 	return (
-		<div
-			className={`w-full flex-1 p-3 md:p-4 border ${
-				!hasError ? 'border-white-faint' : 'border-missionError'
-			} rounded-2xl`}>
+		<AddressInputStyled className={`w-full flex-1 p-3 md:p-4 border`} hasError={hasError}>
 			<div className="flex place-content-between">
 				<div className="flex gap-2 items-center">
 					<img alt={chainName} className="w-5 h-5" src={chainImage} />
-					<p className="text-white-high">
+					<p>
 						{chainName} - {label}
 					</p>
 				</div>
-				{!!hasError && <p className="text-error">Invalid address</p>}
+				{hasError && <p className="text-error">Invalid address</p>}
 			</div>
 			{isEditing ? (
 				<>
@@ -53,77 +53,55 @@ export const AddressInput = ({
 							Warning: Transferring to a central exchange address or the wrong address could result in loss of funds.
 						</p>
 					</div>
-					<div className="flex gap-2 place-content-between p-1 bg-background rounded-lg">
-						<AmountInput
-							style={{ fontSize: '14px', textAlign: 'left' }}
-							value={address}
-							onChange={e => onChangeAddress && onChangeAddress(e.target.value)}
-						/>
-						<button
-							onClick={() => {
-								if (onChangeConfirm) {
-									onChangeConfirm(true);
-								}
+					<TextField
+						label=""
+						value={address}
+						onChange={e => onChangeAddress && onChangeAddress(e.target.value)}
+						buttonText="Enter"
+						onButtonClick={() => {
+							if (onChangeConfirm) {
+								onChangeConfirm(true);
+							}
 
-								setIsEditing(false);
-							}}
-							className={classNames('my-auto p-1.5 flex justify-center items-center rounded-md md:static', {
-								'bg-primary-200 hover:opacity-75 cursor-pointer ': didVerifyWithdrawRisks && !hasError,
-								'opacity-30': !didVerifyWithdrawRisks || !!hasError || !address,
-							})}
-							disabled={!didVerifyWithdrawRisks || !!hasError || !address}>
-							<p className="text-xs text-white-high leading-none">Enter</p>
-						</button>
-					</div>
-					<div className="flex space-between">
-						<div className="flex mt-2 mb-1 mr-3 items-center relative">
-							{onGetKeplAddress && (
-								<Button onClick={onGetKeplAddress} backgroundStyle="primary" style={{ marginRight: '8px' }}>
-									<img alt="Keplr" className="w-5 h-5 mr-1.5" src="/public/assets/other-logos/keplr.png" />
-									<p className="text-xs text-white-high leading-none">Keplr Address</p>
-								</Button>
-							)}
-							{onGetMetamaskAddress && (
-								<Button onClick={onGetMetamaskAddress} backgroundStyle="primary">
-									<img alt="Metamask" className="w-6 h-6 mr-1" src="/public/assets/other-logos/metamask.png" />
-									<p className="text-xs text-white-high leading-none">Metamask Address</p>
-								</Button>
-							)}
-						</div>
-						<label
-							htmlFor="checkbox"
-							className="text-xs flex justify-end items-center mr-2 mt-2 mb-1 cursor-pointer"
-							onClick={() => setDidVerifyWithdrawRisks(!didVerifyWithdrawRisks)}>
-							{didVerifyWithdrawRisks ? (
-								<div className="mr-2.5">
-									<svg width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
-										<path
-											fillRule="evenodd"
-											clipRule="evenodd"
-											d="M4 2H20C21.1046 2 22 2.89543 22 4V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4C2 2.89543 2.89543 2 4 2ZM0 4C0 1.79086 1.79086 0 4 0H20C22.2091 0 24 1.79086 24 4V20C24 22.2091 22.2091 24 20 24H4C1.79086 24 0 22.2091 0 20V4ZM20.6717 7.43656C21.1889 6.78946 21.0837 5.84556 20.4366 5.32831C19.7895 4.81106 18.8456 4.91633 18.3283 5.56344L10.2439 15.6773L5.61855 10.5006C5.06659 9.88282 4.11834 9.82948 3.50058 10.3814C2.88282 10.9334 2.82948 11.8817 3.38145 12.4994L9.18914 18.9994C9.48329 19.3286 9.90753 19.5115 10.3488 19.4994C10.7902 19.4873 11.2037 19.2814 11.4794 18.9366L20.6717 7.43656Z"
-											fill="white"
-										/>
-									</svg>
-								</div>
-							) : (
-								<div className="w-6 h-6 border-2 border-iconDefault mr-2.5 rounded" />
-							)}
-							I verify that I am sending to the correct address
-						</label>
+							setIsEditing(false);
+						}}
+						disabledButton={!didVerifyWithdrawRisks || hasError || !address}
+					/>
+					<div className="flex mt-2 mb-1 mr-3 space-between items-center relative">
+						{onGetKeplAddress && (
+							<Button
+								onClick={onGetKeplAddress}
+								backgroundStyle="primary"
+								style={{ marginRight: '8px', display: 'flex', alignItems: 'center' }}>
+								<img alt="Keplr" className="w-5 h-5 mr-1.5" src="/public/assets/other-logos/keplr.png" />
+								<p className="text-xs text-white-high leading-none">Keplr Address</p>
+							</Button>
+						)}
+						{onGetMetamaskAddress && (
+							<Button
+								onClick={onGetMetamaskAddress}
+								backgroundStyle="primary"
+								style={{ marginRight: '8px', display: 'flex', alignItems: 'center' }}>
+								<img alt="Metamask" className="w-6 h-6 mr-1" src="/public/assets/other-logos/metamask.png" />
+								<p className="text-xs text-white-high leading-none">Metamask Address</p>
+							</Button>
+						)}
+						<Checkbox
+							label="I verify that I am sending to the correct address"
+							onChange={() => setDidVerifyWithdrawRisks(!didVerifyWithdrawRisks)}
+							labelStyle={{ fontSize: '12px' }}
+						/>
 					</div>
 				</>
 			) : (
-				<p className="text-white-disabled truncate overflow-ellipsis">
+				<p className="truncate overflow-ellipsis">
 					{address}
 					{!isEditing && canEdit && (
 						<Button
 							style={{
 								borderRadius: '12px !important',
-								fontSize: '11px',
-								marginBottom: '3px',
-								marginLeft: '6px',
+								margin: '6px',
 								minWidth: '0',
-								padding: '2px 8px',
 							}}
 							onClick={e => {
 								e.preventDefault();
@@ -139,6 +117,13 @@ export const AddressInput = ({
 					)}
 				</p>
 			)}
-		</div>
+		</AddressInputStyled>
 	);
 };
+
+const AddressInputStyled = styled.div<{ hasError?: boolean }>`
+	border-color: ${props => (props.hasError ? props.theme.error : props.theme.text)};
+	border-radius: 20px;
+
+	color: ${props => props.theme.text};
+`;

--- a/src/pages/ibc-transfer/index.tsx
+++ b/src/pages/ibc-transfer/index.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import { Bech32Address, ChainIdHelper } from '@keplr-wallet/cosmos';
 import { WalletStatus } from '@keplr-wallet/stores';
 import { IBCCurrency } from '@keplr-wallet/types';
@@ -21,6 +21,7 @@ import useWindowSize from 'src/hooks/use-window-size';
 import { useStore } from 'src/stores';
 import { WalletStore } from 'src/stores/wallet';
 import { AddressInput } from './address-input';
+import TextField from 'src/components/insync/text-field/text-field';
 
 // Set counterparty to osmosis
 const counterpartyChainId = EmbedChainInfos[1].chainId;
@@ -468,57 +469,54 @@ const IbcTransferPage: FunctionComponent<React.PropsWithChildren<unknown>> = obs
 	}, [amount, currBal, currency.coinDecimals]);
 
 	return (
-		<div className="w-full h-fit max-w-3xl text-white-high bg-surface rounded-2xl p-8 m-5 mt-21 md:my-10 mx-15 md:mt-10">
-			<h6 className="mb-3 md:mb-4 text-base md:text-lg">IBC Transfer</h6>
-			<section className={`flex flex-col items-center`}>
-				<AddressInput
-					address={senderAddress}
-					chainImage={isWithdraw ? rebusImage : osmosisImage}
-					chainName={isWithdraw ? chain.chainName : counterpartyChainStore.chainName}
-					label="From"
-				/>
-				<SwapButton className="rounded-full gradient-blue" onClick={swapTokens}>
-					<img src="/public/assets/icons/swap.svg" />
-				</SwapButton>
-				<AddressInput
-					address={recipient}
-					canEdit={true}
-					chainImage={isWithdraw ? osmosisImage : rebusImage}
-					chainName={isWithdraw ? counterpartyChainStore.chainName : chain.chainName}
-					hasError={hasError}
-					label="To"
-					onChangeAddress={setRecipient}
-					onChangeConfirm={setDidConfirm}
-					onGetKeplAddress={onGetKeplAddress}
-					onGetMetamaskAddress={!isWithdraw ? onGetMetamaskAddress : undefined}
-				/>
-			</section>
-			<h6 className="text-base md:text-lg mt-7">Amount To {isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
-			<div className="mt-3 md:mt-4 w-full p-0 md:p-5 border-0 md:border border-secondary-50 border-opacity-60 rounded-2xl">
-				<p className="text-sm md:text-base mb-2">
-					Available balance:{' '}
-					<span className="text-primary-50">
-						{currBal
-							.upperCase(true)
-							.trim(true)
-							.maxDecimals(6)
-							.toString()}
-					</span>
-				</p>
-				<div
-					className="py-2 px-2.5 bg-background rounded-lg flex gap-5 relative"
-					style={{ gridTemplateColumns: 'calc(100% - 60px) 40px' }}>
-					<AmountInput
+		<div className="w-full h-fit max-w-3xl p-8 m-5 mt-21 md:my-10 mx-15 md:mt-10">
+			<IBCTransferStyled>
+				<h6 className="mb-3 md:mb-4 text-base md:text-lg">IBC Transfer</h6>
+				<section className={`flex flex-col items-center`}>
+					<AddressInput
+						address={senderAddress}
+						chainImage={isWithdraw ? rebusImage : osmosisImage}
+						chainName={isWithdraw ? chain.chainName : counterpartyChainStore.chainName}
+						label="From"
+					/>
+					<SwapButton className="rounded-full gradient-blue" onClick={swapTokens}>
+						<img src="/public/assets/icons/swap.svg" />
+					</SwapButton>
+					<AddressInput
+						address={recipient}
+						canEdit={true}
+						chainImage={isWithdraw ? osmosisImage : rebusImage}
+						chainName={isWithdraw ? counterpartyChainStore.chainName : chain.chainName}
+						hasError={hasError}
+						label="To"
+						onChangeAddress={setRecipient}
+						onChangeConfirm={setDidConfirm}
+						onGetKeplAddress={onGetKeplAddress}
+						onGetMetamaskAddress={!isWithdraw ? onGetMetamaskAddress : undefined}
+					/>
+				</section>
+				<h6 className="text-base md:text-lg mt-7">Amount To {isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
+				<div className="mt-3 md:mt-4 w-full p-0 md:p-5 border-0 md:border border-secondary-50 border-opacity-60 rounded-2xl">
+					<p className="text-sm md:text-base mb-2">
+						Available balance:{' '}
+						<span className="text-bold">
+							{currBal
+								.upperCase(true)
+								.trim(true)
+								.maxDecimals(6)
+								.toString()}
+						</span>
+					</p>
+					<TextField
+						label=""
 						type="number"
-						style={{ color: colorWhiteEmphasis }}
+						value={amount}
 						onChange={e => {
 							e.preventDefault();
 							setAmount(e.currentTarget.value);
 						}}
-						value={amount}
-					/>
-					<button
-						onClick={() => {
+						buttonText="MAX"
+						onButtonClick={() => {
 							setIsMax(true);
 							setAmount(
 								currBal
@@ -529,51 +527,52 @@ const IbcTransferPage: FunctionComponent<React.PropsWithChildren<unknown>> = obs
 									.replace(/,/g, '')
 							);
 						}}
-						className={classNames(
-							'my-auto p-1.5 hover:opacity-75 cursor-pointer flex justify-center items-center rounded-md absolute top-2 right-2 md:static',
-							!isMax && 'bg-white-faint',
-							isMax && 'bg-primary-200'
-						)}>
-						<p className="text-xs text-white-high leading-none">MAX</p>
-					</button>
-				</div>
-			</div>
-			<div className="w-full mt-6 md:mt-9 flex items-center justify-center">
-				{!isAccountConnected ? (
-					<ConnectAccountButton
-						className="w-full md:w-2/3 p-4 md:p-6 rounded-2xl"
-						style={{ marginTop: isMobileView ? '16px' : '32px' }}
-						onClick={e => {
-							e.preventDefault();
-							connectAccount();
-						}}
 					/>
-				) : (
-					<Button disabled={isDisabled} onClick={onSubmit}>
-						{isLoading ||
-						(isWithdraw && account.isSendingMsg === 'ibcTransfer') ||
-						(!isWithdraw && counterpartyAccount.isSendingMsg === 'ibcTransfer') ? (
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								fill="none"
-								className="animate-spin md:-ml-1 md:mr-3 h-5 w-5 text-white"
-								viewBox="0 0 24 24">
-								<circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
-								<path
-									fill="currentColor"
-									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-									className="opacity-75"
-								/>
-							</svg>
-						) : (
-							<h6 className="text-base md:text-lg">{isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
-						)}
-					</Button>
-				)}
-			</div>
+				</div>
+				<div className="w-full mt-6 md:mt-9 flex items-center justify-center">
+					{!isAccountConnected ? (
+						<ConnectAccountButton
+							className="w-full md:w-2/3 p-4 md:p-6 rounded-2xl"
+							style={{ marginTop: isMobileView ? '16px' : '32px' }}
+							onClick={e => {
+								e.preventDefault();
+								connectAccount();
+							}}
+						/>
+					) : (
+						<Button disabled={isDisabled} onClick={onSubmit} style={{ display: 'flex', alignItems: 'center' }}>
+							{isLoading ||
+							(isWithdraw && account.isSendingMsg === 'ibcTransfer') ||
+							(!isWithdraw && counterpartyAccount.isSendingMsg === 'ibcTransfer') ? (
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									className="animate-spin h-5 w-5 text-white "
+									viewBox="0 0 24 24">
+									<circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" className="opacity-25" />
+									<path
+										fill="currentColor"
+										d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+										className="opacity-75"
+									/>
+								</svg>
+							) : (
+								<h6 className="text-base md:text-lg">{isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
+							)}
+						</Button>
+					)}
+				</div>
+			</IBCTransferStyled>
 		</div>
 	);
 });
+
+const IBCTransferStyled = styled.div`
+	background-color: ${props => props.theme.gray.lightest};
+	color: ${props => props.theme.text};
+	border-radius: 20px;
+	padding: 10px;
+`;
 
 const SwapButton = styled(IconButton)`
 	margin: 8px !important;

--- a/src/pages/nft-id/index.tsx
+++ b/src/pages/nft-id/index.tsx
@@ -20,6 +20,7 @@ import SuccessDialog from '../stake/delegate-dialog/success-dialog';
 import QuizPage from './questions/quiz';
 import 'src/styles/insync.scss';
 import { ROUTES } from 'src/constants/routes';
+import styled from 'styled-components';
 
 const cookies = new Cookies();
 
@@ -79,7 +80,7 @@ const NftIdPage: FunctionComponent<React.PropsWithChildren<unknown>> = observer(
 
 	if (!address || (walletStore.isLoaded && !isValidWalletType)) {
 		return (
-			<div className="w-full h-full flex flex-col items-center justify-center font-karla py-5 px-5 pt-21 md:py-10 md:px-15">
+			<NFTPageStyled className="w-full h-full flex flex-col items-center justify-center font-karla py-5 px-5 pt-21 md:py-10 md:px-15">
 				<p className="title text-center text-xl pb-6">
 					{address
 						? 'This wallet is not supported for the NFT ID feature'
@@ -109,7 +110,7 @@ const NftIdPage: FunctionComponent<React.PropsWithChildren<unknown>> = observer(
 						}}
 					/>
 				)}
-			</div>
+			</NFTPageStyled>
 		);
 	}
 
@@ -129,5 +130,9 @@ const NftIdPage: FunctionComponent<React.PropsWithChildren<unknown>> = observer(
 		</>
 	);
 });
+
+const NFTPageStyled = styled.div`
+	color: ${props => props.theme.text};
+`;
 
 export default NftIdPage;

--- a/src/pages/nft-id/questions/getting-started.tsx
+++ b/src/pages/nft-id/questions/getting-started.tsx
@@ -1,7 +1,9 @@
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import React, { FunctionComponent } from 'react';
 import gettingStarted from 'src/assets/nft-id-quiz/quiz-passing.png';
 import { Loader } from 'src/components/common/loader';
+import { useTheme } from 'styled-components';
+import { Button } from 'src/components/common/button';
 
 type GettingStartedProps = {
 	disabled?: boolean;
@@ -17,22 +19,31 @@ const loaderStyles: React.CSSProperties = {
 };
 
 const GettingStarted: FunctionComponent<React.PropsWithChildren<GettingStartedProps>> = ({ disabled, onClick }) => {
+	const theme = useTheme();
 	return (
 		<>
 			<div className="image-wrapper">
-				<img alt="getting-started" src={gettingStarted} />
+				<img
+					alt="getting-started"
+					src={gettingStarted}
+					style={{ filter: theme.text === '#FFFFFF' ? 'none' : 'invert(1)' }}
+				/>
 			</div>
-			<p className="title text-center text-xl-2 py-6 leading-8">
+			<TextStyled className="title text-center text-xl-2 py-6 leading-8">
 				Before you create your NFTID, lets make sure you know what it is.
-			</p>
-			<p className="sub-text text-center text-base text-white-mid px-8">
+			</TextStyled>
+			<TextStyled className="sub-text text-center text-base text-white-mid px-8">
 				You will be asked 5 questions at random, you need to answer at least 4 of them correctly.
-			</p>
-			<button disabled={disabled} onClick={onClick} className="bg-blue1 py-2 px-15 rounded-lg mt-6 relative">
+			</TextStyled>
+			<Button disabled={disabled} backgroundStyle="primary" onClick={onClick} style={{ marginTop: '10px' }}>
 				{disabled && <Loader className="h-7" style={loaderStyles} />}Get Started
-			</button>
+			</Button>
 		</>
 	);
 };
+
+const TextStyled = styled.div`
+	color: ${props => props.theme.text};
+`;
 
 export default GettingStarted;

--- a/src/pages/nft-id/questions/quiz-complete.tsx
+++ b/src/pages/nft-id/questions/quiz-complete.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react-lite';
 import quizPassed from 'src/assets/nft-id-quiz/quiz-passing.png';
 import quizFailed from 'src/assets/nft-id-quiz/quiz-failed.png';
 import { Button } from 'src/components/common/button';
+import { styled, useTheme } from 'styled-components';
 
 type QuizCompleteProps = {
 	creatingIdRecord?: boolean;
@@ -16,6 +17,7 @@ type QuizCompleteProps = {
 const QuizComplete: FunctionComponent<React.PropsWithChildren<QuizCompleteProps>> = observer(
 	({ creatingIdRecord, hasPassed, onClick }) => {
 		const { questionsStore } = useStore();
+		const theme = useTheme();
 
 		const onDocumentationClick = useCallback(() => {
 			window.open('https://medium.com/@RebusChain/nftid-nifdy-a-new-take-on-identity-with-rebus-76cb074a1dba');
@@ -28,16 +30,20 @@ const QuizComplete: FunctionComponent<React.PropsWithChildren<QuizCompleteProps>
 				) : (
 					<>
 						<div className="image-wrapper">
-							<img alt="quiz-complete" src={hasPassed ? quizPassed : quizFailed} />
+							<img
+								alt="quiz-complete"
+								src={hasPassed ? quizPassed : quizFailed}
+								style={{ filter: theme.text === '#FFFFFF' ? 'none' : 'invert(1)' }}
+							/>
 						</div>
-						<p className="title text-center text-xl-2 py-6 leading-8">
+						<TextStyled className="title text-center text-xl-2 py-6 leading-8">
 							{hasPassed ? 'Congrats!' : 'Unfortunately, you didn’t pass.'}
-						</p>
-						<p className="sub-text text-center text-base text-white-mid px-8 mb-3">
+						</TextStyled>
+						<TextStyled className="sub-text text-center text-base text-white-mid px-8 mb-3">
 							{hasPassed
 								? 'You passed! You may now create your NFTID.'
 								: 'Hit our docs and study up, you can try again as soon as you think you’re ready.'}
-						</p>
+						</TextStyled>
 
 						<Button
 							backgroundStyle="secondary"
@@ -51,5 +57,9 @@ const QuizComplete: FunctionComponent<React.PropsWithChildren<QuizCompleteProps>
 		);
 	}
 );
+
+const TextStyled = styled.p`
+	color: ${props => props.theme.text};
+`;
 
 export default QuizComplete;

--- a/src/pages/tools/components/address-converter/index.tsx
+++ b/src/pages/tools/components/address-converter/index.tsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 import { snackbarActions } from 'src/reducers/slices';
 import ConfirmDialog from 'src/pages/stake/delegate-dialog/confirm-dialog';
 import { useActions } from 'src/hooks/use-actions';
-import { InsyncWrapper } from 'src/components/insync/insync-wrapper';
+import TextField from 'src/components/insync/text-field/text-field';
+import styled from 'styled-components';
 
 const AddressConverter: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
 	const navigate = useNavigate();
@@ -46,56 +47,48 @@ const AddressConverter: FunctionComponent<React.PropsWithChildren<unknown>> = ()
 	}, [address]);
 
 	return (
-		<InsyncWrapper>
+		<ConverterStyled>
 			<div
-				className="p-4.5 md:pt-4.5 bg-card rounded-2xl font-body flex flex-col items-center mx-auto"
+				className="p-4.5 md:pt-4.5 font-body flex flex-col items-center mx-auto"
 				style={{ maxWidth: '100%', width: '500px' }}>
-				<h1 className="text-lg font-semibold">Address Converter</h1>
+				<h1 className="text-lg font-semibold mb-4">Address Converter</h1>
 
 				<div className="flex flex-col w-full">
-					<div className="mt-4" style={{ height: '32px' }}>
-						Input Address
-					</div>
-					<input
-						className="text-white-high rounded-lg bg-background text-left font-title p-2"
-						onChange={e => setAddress(e.currentTarget.value)}
-						placeholder="0x... / rebus1..."
+					<TextField
+						label="Input Address"
 						value={address}
+						placeholder="0x... / rebus1..."
+						onChange={e => setAddress(e.currentTarget.value)}
 					/>
 
-					<div className="mt-3" style={{ height: '32px' }}>
-						Converted
-					</div>
-					<div className="relative rounded-lg bg-background">
-						<div
-							className={classNames(
-								'p-2',
-								'pr-10',
-								error && 'text-missionError',
-								!convertedAddress && !error && 'opacity-60'
-							)}
-							style={{ boxSizing: 'content-box' }}>
-							{error || convertedAddress || 'Result...'}
-						</div>
-						<button
-							className="flex-1 items-center justify-center absolute top-1.5 right-2 py-1.5 px-1"
-							onClick={() => {
-								copyTextToClipboard(convertedAddress, () => showMessage('Copied to clipboard!'));
-							}}>
-							<img className="text-white-high" src="/public/assets/common/copy.svg" />
-						</button>
-					</div>
+					<TextField
+						label="Converted"
+						value={error || convertedAddress || 'Result...'}
+						onChange={() => null}
+						assistiveText={!convertedAddress && !error ? 'No result available' : ''}
+						buttonText="Copy"
+						onButtonClick={() => {
+							copyTextToClipboard(convertedAddress, () => showMessage('Copied to clipboard!'));
+						}}
+					/>
 				</div>
 				<ConfirmDialog
 					content={`Transfer only REBUS using this conversion tool. All other assets will be lost. To transfer other assets, please use the asset page.`}
-					isOpen={isConfirmDialogOpen}
+					isOpen={false} //isConfirmDialogOpen, FALSE for testing
 					onClose={onNotConfirmed}
 					onConfirm={onConfirm}
 					title="REBUS Conversion Tool"
 				/>
 			</div>
-		</InsyncWrapper>
+		</ConverterStyled>
 	);
 };
+
+const ConverterStyled = styled.div`
+	background-color: ${props => props.theme.gray.lightest};
+	border-radius: 20px;
+	color: ${props => props.theme.text};
+	width: 50%;
+`;
 
 export { AddressConverter };

--- a/src/pages/tools/index.tsx
+++ b/src/pages/tools/index.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import React, { FunctionComponent } from 'react';
 import { FullScreenContainer } from 'src/components/layouts/containers';
 import SnackbarMessage from '../../components/insync/snackbar-message';
@@ -14,6 +14,9 @@ const ToolsPage: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
 };
 
 const FullScreenContainerWithPadding = styled(FullScreenContainer)`
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	padding: 84px 20px 20px;
 
 	@media (min-width: 768px) {

--- a/src/pages/wallet-connect/index.tsx
+++ b/src/pages/wallet-connect/index.tsx
@@ -16,6 +16,7 @@ import { snackbarActions } from 'src/reducers/slices';
 import { disconnect } from 'src/reducers/extra-actions';
 import SnackbarMessage from '../../components/insync/snackbar-message';
 import { config } from '../../config-insync';
+import { styled, useTheme } from 'styled-components';
 
 const chainId = config.CHAIN_ID;
 
@@ -60,6 +61,7 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 	const isConnected = isAccountConnected || walletStore.isLoaded;
 	const account = accountStore.getAccount(chainStore.current.chainId);
 	const address = walletStore.isLoaded ? walletStore.rebusAddress : account.bech32Address;
+	const theme = useTheme();
 
 	useEffect(() => {
 		if (!serverId || !userId) {
@@ -152,9 +154,10 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 	if (success) {
 		content = (
 			<>
-				<h5 className="text-base md:text-lg mb-1 text-white-high mb-5">Successfully linked user to wallet</h5>
+				<h5 className="text-base md:text-lg mb-1 mb-5">Successfully linked user to wallet</h5>
 				{redirectUrl && (
 					<Button
+						backgroundStyle="primary"
 						onClick={e => {
 							e.preventDefault();
 							window.open(redirectUrl);
@@ -176,14 +179,14 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 
 		content = (
 			<>
-				<div className="text-left p-3 md:p-5 rounded-2xl bg-background flex items-center">
+				<div className="text-left p-3 md:p-5 rounded-2xl flex items-center">
 					<img src={walletConnected?.logoUrl} className="w-12 mr-3 md:w-16 md:mr-5" />
-					<div>
-						<h5 className="text-base md:text-lg mb-1 text-white-high">{walletConnected?.name}</h5>
+					<ContentStyled>
+						<h5 className="text-base md:text-lg mb-1">{walletConnected?.name}</h5>
 						<p className="text-xs md:text-sm text-iconDefault">{walletConnected?.description}</p>
-					</div>
+					</ContentStyled>
 				</div>
-				<div className="flex mt-5">
+				<div className="flex mt-5" style={{ display: 'flex', justifyContent: 'space-between' }}>
 					<Button
 						disabled={loading}
 						onClick={e => {
@@ -216,8 +219,8 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 	} else if (!WALLET_LIST.length) {
 		content = (
 			<>
-				<h4 className="text-lg md:text-xl text-white-high">Connect Wallet</h4>
-				<p className="text-xs md:text-sm text-white-high mt-4">
+				<h4 className="text-lg md:text-xl">Connect Wallet</h4>
+				<p className="text-xs md:text-sm mt-4">
 					This browser does not support any wallet extensions, please use either Chrome or Firefox.
 				</p>
 			</>
@@ -225,17 +228,27 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 	} else {
 		content = (
 			<>
-				<h4 className="text-lg md:text-xl text-white-high">Connect Wallet</h4>
-				<h5 className="text-base text-white mt-2">Choose your wallet to connect with the Discord bot integration</h5>
+				<h4 className="text-lg md:text-xl">Connect Wallet</h4>
+				<h5 className="text-base mt-2">Choose your wallet to connect with the Discord bot integration</h5>
 				{WALLET_LIST.filter(wallet => {
 					if (isMobile && wallet.type == 'extension') {
 						return false;
 					}
 					return true;
 				}).map(wallet => (
-					<button
+					<Button
 						key={wallet.name}
-						className="w-full text-left p-3 md:p-5 rounded-2xl bg-background flex items-center mt-4 md:mt-5"
+						backgroundStyle="secondary"
+						style={{
+							width: '100%',
+							display: 'flex',
+							flexDirection: 'row',
+							alignItems: 'flex-start',
+							justifyContent: 'flex-start',
+							height: 'auto',
+							marginBottom: '10px',
+							marginTop: '10px',
+						}}
 						onClick={async () => {
 							localStorage.setItem(KeyConnectingWalletType, wallet.type);
 							localStorage.setItem(KeyConnectingWalletName, wallet.walletType || '');
@@ -253,12 +266,25 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 								account.init();
 							}
 						}}>
-						<img src={wallet.logoUrl} className="w-12 mr-3 md:w-16 md:mr-5" />
-						<div>
-							<h5 className="text-base md:text-lg mb-1 text-white-high">{wallet.name}</h5>
-							<p className="text-xs md:text-sm text-iconDefault">{wallet.description}</p>
+						<img
+							src={wallet.logoUrl}
+							className="w-12 mr-3 md:w-16 md:mr-5"
+							style={{
+								maxWidth: '100%',
+								maxHeight: '100%',
+							}}
+						/>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								textAlign: 'left',
+								color: theme.text,
+							}}>
+							<h5 className="text-base md:text-lg mb-1">{wallet.name}</h5>
+							<p className="text-xs md:text-sm">{wallet.description}</p>
 						</div>
-					</button>
+					</Button>
 				))}
 			</>
 		);
@@ -267,9 +293,9 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 	return (
 		<FullScreenContainer>
 			<div className="flex items-center justify-center h-full pt-20 md:pt-0">
-				<div className="relative w-full mt-4 md:mt-0 mx-10 md:mx-0 md:min-w-modal md:max-w-modal px-4 py-5 md:p-8 bg-surface shadow-elevation-24dp rounded-2xl z-10">
+				<ContentStyled className="relative w-full mt-4 md:mt-0 mx-10 md:mx-0 md:min-w-modal md:max-w-modal px-4 py-5 md:p-8 shadow-elevation-24dp rounded-2xl z-10">
 					{content}
-				</div>
+				</ContentStyled>
 			</div>
 			<SnackbarMessage />
 		</FullScreenContainer>
@@ -277,3 +303,8 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 });
 
 export default WalletConnect;
+
+const ContentStyled = styled.div`
+	background: ${props => props.theme.background};
+	color: ${props => props.theme.text};
+`;


### PR DESCRIPTION
This reskins Tools, NFT ID, IBC Transfer, and Wallet Connect pages. I believe I reskinned all the necessary pages for NFT ID, such as the quiz and initial setup. The Assets page is reskinned in the table component branch (DEV-686), casue that's the only implementation of a table without Stake/Vote. Lastly, I redid the DateInput component because I don't think the Material UI Date Picker was compatible with styled-components

Tools (light mode):
![Screenshot 2023-10-10 at 12 22 16 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/fbebd434-aa12-499c-af11-f8eba1878ae4)

Tools (dark mode):
![Screenshot 2023-10-10 at 12 22 09 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/f3d6435c-58f4-4e88-a7e8-9c5351bdfeaf)

NFT ID (light mode):
![Screenshot 2023-10-10 at 12 19 55 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/40c79351-9060-4ff7-a41c-ab061ffe89a3)

NFT ID (dark mode) showing Color Theme:
![Screenshot 2023-10-10 at 12 21 58 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/0b6814ed-5069-440c-9000-cf0b53b648f1)

IBC Transfer (light mode):
![Screenshot 2023-10-10 at 12 19 41 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/513419db-6bbb-40e3-8fb2-282caae2d8c5)

IBC Transfer (dark mode):
![Screenshot 2023-10-10 at 12 19 06 PM](https://github.com/rebuschain/rebus.app.web/assets/143646590/5aa522a3-c5f6-4c65-bb8a-4c8353c40123)