### PR TITLE
DEV-713 Rebus Network Detection

### DIFF
--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -46,9 +46,9 @@ export const WALLET_LIST: WalletConfig[] = [
 		version: KEPLR_VERSION,
 	},
 	isExtensionEnvironment && {
-		name: 'Keplr Wallet (EVMOS)',
+		name: 'Keplr Wallet (EVM)',
 		description:
-			'Keplr Browser Extension (Only select this option if you were using the EVMOS chain with Keplr, you will able to connect to the Rebus chain with the Rebus address derived from the EVMOS address to redeem the airdrop, and if you already connected to the Keplr wallet normally, you might have to remove the rebus network in the Keplr wallet and try connecting again)',
+			'Keplr Browser Extension (Only select this option if you were using the EVM chain with Keplr, you will able to connect to the Rebus chain with the Rebus address derived from the EVM address to redeem the airdrop, and if you already connected to the Keplr wallet normally, you might have to remove the rebus network in the Keplr wallet and try connecting again)',
 		logoUrl: '/public/assets/other-logos/keplr.png',
 		type: 'extension',
 		walletType: 'keplr-evmos',

--- a/src/dialogs/connect-wallet.tsx
+++ b/src/dialogs/connect-wallet.tsx
@@ -296,7 +296,6 @@ export const ConnectWalletDialog = wrapBaseDialog(
 	observer(({ initialFocus, close }: { initialFocus: React.RefObject<HTMLDivElement>; close: () => void }) => {
 		const { connectWalletManager, chainStore, accountStore, walletStore, setIsEvmos } = useStore();
 		const [isMobile] = useState(() => checkIsMobile());
-		const { isAccountConnected } = useAccountConnection();
 		const [showSnackbar] = useActions([actions.showSnackbar]);
 		const account = accountStore.getAccount(chainStore.current.chainId);
 
@@ -308,11 +307,11 @@ export const ConnectWalletDialog = wrapBaseDialog(
 				localStorage.setItem(KeyConnectingWalletType, wallet.type);
 				localStorage.removeItem(KeyConnectingWalletName);
 				connectWalletManager.setWalletName('');
-				setIsEvmos(chainStore.current.chainId, false);
+				setIsEvmos(chainStore.current.chainId, false, showSnackbar);
 				account.init();
 				close();
 			}
-		}, [account, accountStore, chainStore, close, connectWalletManager, isMobile, setIsEvmos]);
+		}, [account, accountStore, chainStore, close, connectWalletManager, isMobile, setIsEvmos, showSnackbar]);
 
 		if (!WALLET_LIST.length) {
 			return (
@@ -352,7 +351,7 @@ export const ConnectWalletDialog = wrapBaseDialog(
 									showSnackbar((err as any)?.message || err);
 								}
 							} else {
-								setIsEvmos(chainStore.current.chainId, wallet.walletType === 'keplr-evmos');
+								setIsEvmos(chainStore.current.chainId, wallet.walletType === 'keplr-evmos', showSnackbar);
 								account.init();
 							}
 							close();

--- a/src/hooks/account/context.tsx
+++ b/src/hooks/account/context.tsx
@@ -9,6 +9,8 @@ import {
 import { useStore } from 'src/stores';
 import { getKeplrFromWindow, WalletStatus } from '@keplr-wallet/stores';
 import { observer } from 'mobx-react-lite';
+import { useActions } from '../use-actions';
+import { actions } from 'src/reducers/slices/snackbar';
 
 export interface AccountConnection {
 	isAccountConnected: boolean | WalletType;
@@ -23,6 +25,7 @@ export const AccountConnectionProvider: FunctionComponent<React.PropsWithChildre
 	({ children }) => {
 		const { chainStore, accountStore, walletStore, connectWalletManager, setIsEvmos } = useStore();
 		const [isOpenDialog, setIsOpenDialog] = useState(false);
+		const [showSnackbar] = useActions([actions.showSnackbar]);
 
 		const account = accountStore.getAccount(chainStore.current.chainId);
 
@@ -82,7 +85,11 @@ export const AccountConnectionProvider: FunctionComponent<React.PropsWithChildre
 						connectWalletManager.disableAutoConnect();
 					}
 				} else if (!!connectWalletManager.autoConnectingWalletType && account.walletStatus === WalletStatus.NotInit) {
-					setIsEvmos(chainStore.current.chainId, connectWalletManager.connectingWalletName === 'keplr-evmos');
+					setIsEvmos(
+						chainStore.current.chainId,
+						connectWalletManager.connectingWalletName === 'keplr-evmos',
+						showSnackbar
+					);
 					account.init();
 				}
 			});
@@ -93,6 +100,7 @@ export const AccountConnectionProvider: FunctionComponent<React.PropsWithChildre
 			connectWalletManager.autoConnectingWalletType,
 			connectWalletManager.connectingWalletName,
 			setIsEvmos,
+			showSnackbar,
 			walletStore,
 		]);
 

--- a/src/pages/wallet-connect/index.tsx
+++ b/src/pages/wallet-connect/index.tsx
@@ -75,10 +75,10 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 			localStorage.setItem(KeyConnectingWalletType, wallet.type);
 			localStorage.removeItem(KeyConnectingWalletName);
 			connectWalletManager.setWalletName('');
-			setIsEvmos(chainStore.current.chainId, false);
+			setIsEvmos(chainStore.current.chainId, false, showMessage);
 			account.init();
 		}
-	}, [account, accountStore, chainStore, connectWalletManager, isConnected, isMobile, setIsEvmos]);
+	}, [account, accountStore, chainStore, connectWalletManager, isConnected, isMobile, setIsEvmos, showMessage]);
 
 	const onConfirm = useCallback(async () => {
 		setLoading(true);
@@ -249,7 +249,7 @@ const WalletConnect: FunctionComponent<React.PropsWithChildren<unknown>> = obser
 									showMessage((err as any)?.message || err);
 								}
 							} else {
-								setIsEvmos(chainStore.current.chainId, wallet.walletType === 'keplr-evmos');
+								setIsEvmos(chainStore.current.chainId, wallet.walletType === 'keplr-evmos', showMessage);
 								account.init();
 							}
 						}}>

--- a/src/stores/root.ts
+++ b/src/stores/root.ts
@@ -234,7 +234,7 @@ export class RootStore {
 							}
 
 							showMessage(
-								'You are connected to the regular Keplr network, please remove the network in the Keplr wallet to connect to EVMOS'
+								'You are connected to the regular Keplr network, please remove the network in the Keplr wallet to connect to EVM'
 							);
 						} else {
 							const keplrWallet = WALLET_LIST.find(x => x.walletType === 'keplr-evmos');
@@ -243,7 +243,7 @@ export class RootStore {
 							}
 
 							showMessage(
-								'You are connected to the EVMOS Keplr network, please remove the network in the Keplr wallet to connect to the regular network'
+								'You are connected to the EVM Keplr network, please remove the network in the Keplr wallet to connect to the regular network'
 							);
 						}
 					}


### PR DESCRIPTION
- Implement detection of which rebus keplr network user is connected to (evmos)

If the user has EVMOS in their wallet and attempts to connect to regular keplr network on the website, a warning will appear

<img width="1135" alt="Screenshot 2024-02-27 at 2 46 53 PM" src="https://github.com/rebuschain/rebus.app.web/assets/21248862/d059eef1-8ca1-4f2b-86cb-8d16d443bb38">
